### PR TITLE
Document batch inference configuration and usage

### DIFF
--- a/transformer_ee/inference/README_batch_inference.md
+++ b/transformer_ee/inference/README_batch_inference.md
@@ -1,0 +1,106 @@
+# Batch inference tooling
+
+This directory includes a configurable batch inference runner (`batch_inference.py`) that can pair multiple trained model exports with multiple inference CSVs. The typical workflow is:
+
+1. Create a JSON config describing which model trainings you want to run (by training name or by explicit path), and which CSV inference samples to use.
+2. Run `batch_inference.py --pair-config <config.json>`.
+3. Review outputs under the `--output-dir` (default: `InferenceTests/Results`).
+
+## Quick start
+
+Create a config from the example:
+
+```bash
+cp transformer_ee/inference/batch_inference_config.example.json ./batch_inference_config.json
+```
+
+Edit the `model_search_roots`, `models`, `samples`, and `pairs` sections to match your environment. Then run:
+
+```bash
+python transformer_ee/inference/batch_inference.py \
+  --pair-config ./batch_inference_config.json \
+  --output-dir ./InferenceTests/Results \
+  --device cuda:0
+```
+
+## How model discovery works
+
+There are two ways to describe a model:
+
+- **By training name**: supply `training_name` in the `models` list. The script searches each `model_search_roots` entry for a directory containing both `input.json` and `best_model.zip` with a path segment matching the training name. If multiple matches are found (e.g., the same training was run by multiple users), **all matches are used** and each match becomes a separate inference task.
+- **By explicit path**: supply `path` (or `dir`) in the `models` list pointing directly at a model export directory (the one that contains `best_model.zip` and `input.json`).
+
+### Labeling and uniqueness
+
+The `name` field in the `models` list is the label used in output files. It **can be shorter and more human-readable** than the training name. When a training name resolves to multiple model exports, the script appends a suffix derived from the search-root-relative path so each model gets a unique label like:
+
+```
+MyShortLabel::Beam_Like/Flat_Spectra/Ar40/<training_name>/model_<hash>
+```
+
+This keeps outputs distinct across users and duplicate trainings.
+
+## How pair configs are resolved
+
+The config JSON has four sections:
+
+- `model_search_roots`: list of directories to search for model exports when using `training_name`.
+- `models`: list of model definitions (each with `name` and either `training_name` or `path`).
+- `samples`: list of CSV samples (each with `name` and `path`).
+- `pairs`: list of pairings, where `model` and `sample` refer to the **names** defined above.
+
+A minimal example that uses training-name lookup:
+
+```json
+{
+  "model_search_roots": [
+    "/exp/dune/data/users/cborden/MLProject/Training_Samples",
+    "/exp/dune/data/users/rrichi/MLProject/Training_Samples",
+    "/exp/dune/data/users/jbarrow/MLProject/Training_Samples"
+  ],
+  "models": [
+    {
+      "name": "TopModel",
+      "training_name": "Numu_CC_Train_DUNEBeam_Flat_Ar40_p1to10_VectorLeptwNC_eventnum_All_NpNpi_Energy_MAPE_Mom_X_MSE_Mom_Y_MSE_Mom_Z_MSE_Topology_MAE"
+    }
+  ],
+  "samples": [
+    {
+      "name": "sample_placeholder",
+      "path": "/path/to/inference/sample.csv"
+    }
+  ],
+  "pairs": [
+    {
+      "model": "TopModel",
+      "sample": "sample_placeholder"
+    }
+  ]
+}
+```
+
+### Defaults and matching rules
+
+- In `models`, `name` is **optional**. If omitted, the label defaults to the resolved path relative to `model_search_roots` (or the file name if no root applies).
+- In `samples`, `name` is **optional**. If omitted, the label defaults to the file name (or relative to `--sample-root` if used).
+- In `pairs`, `model` and `sample` should reference the **labels** (names) defined in `models` and `samples`. The `model` and `sample` fields do **not** automatically default to `training_name` or `path`—they are labels, and should match whatever label you want to pair.
+
+## Testing & validation
+
+The script supports light-weight smoke tests:
+
+```bash
+python transformer_ee/inference/batch_inference.py \
+  --pair-config ./batch_inference_config.json \
+  --max-samples 100 \
+  --device cpu
+```
+
+- `--max-samples` limits the number of rows per CSV.
+- `--device` can be `cpu`, `cuda`, or `cuda:<index>`.
+
+Outputs include:
+
+- CSV/NPZ outputs per model + sample pair in `--output-dir`.
+- `timings.csv` for per-batch timing.
+- `summary.json` with metadata for each task.

--- a/transformer_ee/inference/batch_inference.py
+++ b/transformer_ee/inference/batch_inference.py
@@ -10,7 +10,7 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 import pandas as pd
 import numpy as np
@@ -172,11 +172,20 @@ def load_pairs_from_config(
     if "pairs" not in payload:
         raise ValueError("Pair config must include a 'pairs' list.")
 
-    model_lookup: Dict[str, Path] = {}
+    training_search_roots = [
+        Path(path).expanduser().resolve() for path in payload.get("model_search_roots", [])
+    ]
+
+    model_lookup: Dict[str, Union[Path, List[Path]]] = {}
     sample_lookup: Dict[str, Path] = {}
 
     for entry in payload.get("models", []):
-        label, resolved = parse_entity(entry, model_root, resolve_model_dir)
+        label, resolved = parse_entity(
+            entry,
+            model_root,
+            resolve_model_dir,
+            training_search_roots=training_search_roots,
+        )
         model_lookup[label] = resolved
 
     for entry in payload.get("samples", []):
@@ -191,6 +200,7 @@ def load_pairs_from_config(
             lookup=model_lookup,
             root=model_root,
             resolver=resolve_model_dir,
+            training_search_roots=training_search_roots,
         )
         sample_label, sample_path = parse_pair_entry(
             pair,
@@ -198,22 +208,40 @@ def load_pairs_from_config(
             lookup=sample_lookup,
             root=sample_root,
             resolver=resolve_sample_path,
+            training_search_roots=None,
         )
-        tasks.append(
-            InferenceTask(
-                model_name=model_label,
-                model_dir=model_path,
-                sample_name=sample_label,
-                sample_path=sample_path,
+        for resolved_label, resolved_path in normalize_model_paths(
+            model_label, model_path, training_search_roots
+        ):
+            tasks.append(
+                InferenceTask(
+                    model_name=resolved_label,
+                    model_dir=resolved_path,
+                    sample_name=sample_label,
+                    sample_path=sample_path,
+                )
             )
-        )
     return tasks
 
 
 def parse_entity(
-    entry, root: Optional[Path], resolver
-) -> Tuple[str, Path]:
+    entry,
+    root: Optional[Path],
+    resolver,
+    training_search_roots: Optional[Sequence[Path]] = None,
+) -> Tuple[str, Union[Path, List[Path]]]:
     if isinstance(entry, dict):
+        if "training_name" in entry:
+            training_name = entry["training_name"]
+            label = entry.get("name", training_name)
+            if not training_search_roots:
+                raise ValueError(
+                    "Model entries with 'training_name' require 'model_search_roots'."
+                )
+            resolved_path = resolve_model_from_training_name(
+                training_name, training_search_roots
+            )
+            return label, resolved_path
         path_value = entry.get("path") or entry.get("dir") or entry.get("file")
         if path_value is None:
             raise ValueError("Each entity dict must include a 'path' field.")
@@ -230,10 +258,11 @@ def parse_entity(
 def parse_pair_entry(
     pair_entry,
     key: str,
-    lookup: Dict[str, Path],
+    lookup: Dict[str, Union[Path, List[Path]]],
     root: Optional[Path],
     resolver,
-) -> Tuple[str, Path]:
+    training_search_roots: Optional[Sequence[Path]] = None,
+) -> Tuple[str, Union[Path, List[Path]]]:
     if isinstance(pair_entry, dict):
         if key in pair_entry:
             value = pair_entry[key]
@@ -253,12 +282,61 @@ def parse_pair_entry(
     if isinstance(value, str) and value in lookup:
         return value, lookup[value]
     if isinstance(value, dict):
-        label, resolved = parse_entity(value, root, resolver)
+        label, resolved = parse_entity(
+            value,
+            root,
+            resolver,
+            training_search_roots=training_search_roots,
+        )
     else:
         resolved = resolver(resolve_relative(value, root))
         label = default_label(resolved, root)
     lookup[label] = resolved
     return label, resolved
+
+
+def resolve_model_from_training_name(
+    training_name: str, search_roots: Sequence[Path]
+) -> List[Path]:
+    candidates: List[Path] = []
+    for root in search_roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("input.json"):
+            if training_name in path.parts and (path.parent / "best_model.zip").exists():
+                candidates.append(path.parent.resolve())
+    unique = sorted({path.resolve() for path in candidates}, key=lambda p: str(p))
+    if not unique:
+        roots = ", ".join(str(root) for root in search_roots)
+        raise FileNotFoundError(
+            f"No model export found for training '{training_name}' under: {roots}"
+        )
+    return unique
+
+
+def normalize_model_paths(
+    label: str,
+    model_path: Union[Path, List[Path]],
+    search_roots: Optional[Sequence[Path]],
+) -> List[Tuple[str, Path]]:
+    if isinstance(model_path, list):
+        return [
+            (label_with_origin(label, path, search_roots), path) for path in model_path
+        ]
+    return [(label, model_path)]
+
+
+def label_with_origin(
+    label: str, model_dir: Path, search_roots: Optional[Sequence[Path]]
+) -> str:
+    if search_roots:
+        for root in search_roots:
+            try:
+                relative = model_dir.relative_to(root)
+            except ValueError:
+                continue
+            return f"{label}::{relative}"
+    return f"{label}::{model_dir.name}"
 
 
 def build_tasks_from_lists(

--- a/transformer_ee/inference/batch_inference_config.example.json
+++ b/transformer_ee/inference/batch_inference_config.example.json
@@ -1,0 +1,25 @@
+{
+  "model_search_roots": [
+    "/exp/dune/data/users/cborden/MLProject/Training_Samples",
+    "/exp/dune/data/users/rrichi/MLProject/Training_Samples",
+    "/exp/dune/data/users/jbarrow/MLProject/Training_Samples"
+  ],
+  "models": [
+    {
+      "name": "Numu_CC_Train_DUNEBeam_Flat_Ar40_p1to10_VectorLeptwNC_eventnum_All_NpNpi_Energy_MAPE_Mom_X_MSE_Mom_Y_MSE_Mom_Z_MSE_Topology_MAE",
+      "training_name": "Numu_CC_Train_DUNEBeam_Flat_Ar40_p1to10_VectorLeptwNC_eventnum_All_NpNpi_Energy_MAPE_Mom_X_MSE_Mom_Y_MSE_Mom_Z_MSE_Topology_MAE"
+    }
+  ],
+  "samples": [
+    {
+      "name": "sample_placeholder",
+      "path": "/path/to/inference/sample.csv"
+    }
+  ],
+  "pairs": [
+    {
+      "model": "Numu_CC_Train_DUNEBeam_Flat_Ar40_p1to10_VectorLeptwNC_eventnum_All_NpNpi_Energy_MAPE_Mom_X_MSE_Mom_Y_MSE_Mom_Z_MSE_Topology_MAE",
+      "sample": "sample_placeholder"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide clear user documentation for the newly-extended batch inference tooling so users can configure and run automated inference reliably.
- Clarify how model discovery works across multiple `model_search_roots` and how duplicate `training_name` matches are handled to avoid ambiguity.
- Explain labeling and pairing rules so users can choose concise `name` fields and understand how those map into `pairs` entries.

### Description
- Add a new README at `transformer_ee/inference/README_batch_inference.md` that explains quick start usage, model discovery, labeling rules, config layout, and smoke-test commands using `batch_inference.py` and `--pair-config`.
- Expand `batch_inference.py` to accept `model_search_roots` and `training_name` lookups via `resolve_model_from_training_name`, return multiple matches, and expand those matches into distinct tasks using `normalize_model_paths` and `label_with_origin` while updating relevant type hints to `Union[Path, List[Path]]`.
- Ensure pair resolution now threads `training_search_roots` through `parse_entity`/`parse_pair_entry` and that `load_pairs_from_config` expands a single pair into multiple `InferenceTask`s when a `training_name` resolves to several export directories.
- Add an example config `transformer_ee/inference/batch_inference_config.example.json` demonstrating `model_search_roots`, use of `training_name`, and a sample `pairs` entry.

### Testing
- No automated tests were executed for this change.  The README documents a lightweight smoke-test command (`python transformer_ee/inference/batch_inference.py --pair-config <config.json> --max-samples 100 --device cpu`) that can be run locally to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697e361f68832eba9d368f6cb13a42)