### PR TITLE
Add optional ROOT eval integration for batch inference

### DIFF
--- a/graph_eval/eval_model.C
+++ b/graph_eval/eval_model.C
@@ -505,9 +505,14 @@ void eval_model(
         gSystem->ChangeDirectory(output_dir);
     }
 
-    std::ifstream infile(filename);
+    std::string filename_abs = filename ? filename : "";
+    if (!filename_abs.empty() && filename_abs.front() != '/') {
+        filename_abs = original_dir + "/" + filename_abs;
+    }
+
+    std::ifstream infile(filename_abs);
     if (!infile.is_open()) {
-        std::cerr << "Could not open file: " << filename << std::endl;
+        std::cerr << "Could not open file: " << filename_abs << std::endl;
         gSystem->ChangeDirectory(original_dir.c_str());
         gROOT->SetBatch(oldBatch); // restore batch state before returning
         return;
@@ -516,7 +521,7 @@ void eval_model(
     // === Parse header ===
     std::string line;
     if (!std::getline(infile, line)) {
-        std::cerr << "Empty file or missing header: " << filename << std::endl;
+        std::cerr << "Empty file or missing header: " << filename_abs << std::endl;
         return;
     }
     std::stringstream header_ss(line);

--- a/graph_eval/eval_model.C
+++ b/graph_eval/eval_model.C
@@ -522,6 +522,8 @@ void eval_model(
     std::string line;
     if (!std::getline(infile, line)) {
         std::cerr << "Empty file or missing header: " << filename_abs << std::endl;
+        gSystem->ChangeDirectory(original_dir.c_str());
+        gROOT->SetBatch(oldBatch);
         return;
     }
     std::stringstream header_ss(line);

--- a/graph_eval/readme.md
+++ b/graph_eval/readme.md
@@ -17,7 +17,7 @@
   - A fixed ellipse (±10% × ±30°)
   - Computation of the fraction of events inside the ellipse
 * Stores the ellipse fractions in a cumulative `ellipse_fraction.csv` file (auto-created and auto-expanded).
-* Appends or updates a directory inside `combined_output.root` named after the model (taken from the final CSV column header).
+* Appends or updates a directory inside `combined_output.root` (or a custom ROOT output name) named after the model (taken from the final CSV column header).
 * Runs in ROOT **batch mode** so plots are written to file without opening GUI windows.
 
 ## Requirements
@@ -42,7 +42,7 @@ A structured ROOT file containing:
 * Contour plots and energy-vs-angle canvases
 * All outputs organized under a directory named after the model
 
-If the ROOT file already exists, new outputs are appended.
+If the ROOT file already exists and is non-empty, new outputs are appended.
 
 ### ellipse_fraction.csv
 A cumulative CSV summary containing:
@@ -58,3 +58,11 @@ Run the macro from a shell:
 
 ```bash
 root -l 'eval_model.C("result.csv")'
+```
+
+Optional arguments can set the output directory, PNG export path/size, and the ROOT
+output filename:
+
+```bash
+root -l 'eval_model.C("result.csv", "./Results", "energy_theta.png", 3000, 2000, "combined_output.root")'
+```

--- a/transformer_ee/inference/README_batch_inference.md
+++ b/transformer_ee/inference/README_batch_inference.md
@@ -113,8 +113,8 @@ Outputs include:
 ## Optional ROOT-based evaluation
 
 You can optionally run the ROOT macro `graph_eval/eval_model.C` for each generated
-CSV to produce `combined_output.root` and `ellipse_fraction.csv`, and to save the
-energy/theta 2D canvas as a PNG.
+CSV to produce `combined_inference_output.root` and `ellipse_fraction.csv`, and to
+save the energy/theta 2D canvas as a PNG.
 
 Example:
 
@@ -131,4 +131,4 @@ python transformer_ee/inference/batch_inference.py \
 
 When enabled, the `summary.json` entries include an `eval_model` section with the
 macro path, output directory, optional PNG path, and any matching row from
-`ellipse_fraction.csv`.
+`ellipse_fraction.csv` (matched against the per-task model label).

--- a/transformer_ee/inference/README_batch_inference.md
+++ b/transformer_ee/inference/README_batch_inference.md
@@ -1,0 +1,134 @@
+# Batch inference tooling
+
+This directory includes a configurable batch inference runner (`batch_inference.py`) that can pair multiple trained model exports with multiple inference CSVs. The typical workflow is:
+
+1. Create a JSON config describing which model trainings you want to run (by training name or by explicit path), and which CSV inference samples to use.
+2. Run `batch_inference.py --pair-config <config.json>`.
+3. Review outputs under the `--output-dir` (default: `InferenceTests/Results`).
+
+## Quick start
+
+Create a config from the example:
+
+```bash
+cp transformer_ee/inference/batch_inference_config.example.json ./batch_inference_config.json
+```
+
+Edit the `model_search_roots`, `models`, `samples`, and `pairs` sections to match your environment. Then run:
+
+```bash
+python transformer_ee/inference/batch_inference.py \
+  --pair-config ./batch_inference_config.json \
+  --output-dir ./InferenceTests/Results \
+  --device cuda:0
+```
+
+## How model discovery works
+
+There are two ways to describe a model:
+
+- **By training name**: supply `training_name` in the `models` list. The script searches each `model_search_roots` entry for a directory containing both `input.json` and `best_model.zip` with a path segment matching the training name. If multiple matches are found (e.g., the same training was run by multiple users), **all matches are used** and each match becomes a separate inference task.
+- **By explicit path**: supply `path` (or `dir`) in the `models` list pointing directly at a model export directory (the one that contains `best_model.zip` and `input.json`).
+
+### Labeling and uniqueness
+
+The `name` field in the `models` list is the label used in output files. It **can be shorter and more human-readable** than the training name. When a training name resolves to multiple model exports, the script appends a suffix derived from the search-root-relative path so each model gets a unique label like:
+
+```
+MyShortLabel::Beam_Like/Flat_Spectra/Ar40/<training_name>/model_<hash>
+```
+
+This keeps outputs distinct across users and duplicate trainings.
+
+## How pair configs are resolved
+
+The config JSON has four sections:
+
+- `model_search_roots`: list of directories to search for model exports when using `training_name`.
+- `models`: list of model definitions (each with `name` and either `training_name` or `path`).
+- `samples`: list of CSV samples (each with `name` and `path`).
+- `pairs`: list of pairings, where `model` and `sample` refer to the **names** defined above.
+
+A minimal example that uses training-name lookup:
+
+```json
+{
+  "model_search_roots": [
+    "/exp/dune/data/users/cborden/MLProject/Training_Samples",
+    "/exp/dune/data/users/rrichi/MLProject/Training_Samples",
+    "/exp/dune/data/users/jbarrow/MLProject/Training_Samples"
+  ],
+  "models": [
+    {
+      "name": "TopModel",
+      "training_name": "Numu_CC_Train_DUNEBeam_Flat_Ar40_p1to10_VectorLeptwNC_eventnum_All_NpNpi_Energy_MAPE_Mom_X_MSE_Mom_Y_MSE_Mom_Z_MSE_Topology_MAE"
+    }
+  ],
+  "samples": [
+    {
+      "name": "sample_placeholder",
+      "path": "/path/to/inference/sample.csv"
+    }
+  ],
+  "pairs": [
+    {
+      "model": "TopModel",
+      "sample": "sample_placeholder"
+    }
+  ]
+}
+```
+
+### Defaults and matching rules
+
+- In `models`, `name` is **optional**. If omitted, the label defaults to the resolved path relative to `model_search_roots` (or the file name if no root applies).
+- In `samples`, `name` is **optional**. If omitted, the label defaults to the file name (or relative to `--sample-root` if used).
+- In `pairs`, `model` and `sample` should reference the **labels** (names) defined in `models` and `samples`. The `model` and `sample` fields do **not** automatically default to `training_name` or `path`—they are labels, and should match whatever label you want to pair.
+
+## Testing & validation
+
+The script supports light-weight smoke tests:
+
+```bash
+python transformer_ee/inference/batch_inference.py \
+  --pair-config ./batch_inference_config.json \
+  --max-samples 100 \
+  --device cpu
+```
+
+- `--max-samples` limits the number of rows per CSV.
+- `--device` can be `cpu`, `cuda`, or `cuda:<index>`.
+
+Note: Some versions of `pred_wBatch.Predictor` do not accept `device` or `num_workers`
+arguments or return batch timing metadata. The batch inference runner detects this and
+falls back to the supported signature automatically, so these flags may be ignored in
+older predictor implementations.
+
+Outputs include:
+
+- CSV/NPZ outputs per model + sample pair in `--output-dir`.
+- `timings.csv` for per-batch timing.
+- `summary.json` with metadata for each task.
+
+## Optional ROOT-based evaluation
+
+You can optionally run the ROOT macro `graph_eval/eval_model.C` for each generated
+CSV to produce `combined_output.root` and `ellipse_fraction.csv`, and to save the
+energy/theta 2D canvas as a PNG.
+
+Example:
+
+```bash
+python transformer_ee/inference/batch_inference.py \
+  --pair-config ./batch_inference_config.json \
+  --output-dir ./InferenceTests/Results \
+  --eval-macro-path ./graph_eval/eval_model.C \
+  --eval-output-dir ./InferenceTests/Results \
+  --eval-save-png \
+  --eval-png-width 3000 \
+  --eval-png-height 2000
+```
+
+When enabled, the `summary.json` entries include an `eval_model` section with the
+macro path, output directory, optional PNG path, and any matching row from
+`ellipse_fraction.csv`.

--- a/transformer_ee/inference/batch_inference.py
+++ b/transformer_ee/inference/batch_inference.py
@@ -650,7 +650,7 @@ def main():
         print("[WARN] No inference tasks to execute.")
         return
 
-    output_dir = Path(args.output_dir).resolve()
+    output_dir = Path(args.output_dir).expanduser().resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
     summary: List[Dict[str, str]] = []
@@ -662,10 +662,10 @@ def main():
             device=args.device,
             num_workers=args.num_workers,
             max_rows=args.max_samples,
-            eval_macro_path=Path(args.eval_macro_path).resolve()
+            eval_macro_path=Path(args.eval_macro_path).expanduser().resolve()
             if args.eval_macro_path
             else None,
-            eval_output_dir=Path(args.eval_output_dir).resolve()
+            eval_output_dir=Path(args.eval_output_dir).expanduser().resolve()
             if args.eval_output_dir
             else None,
             eval_save_png=args.eval_save_png,

--- a/transformer_ee/inference/batch_inference_config.example.json
+++ b/transformer_ee/inference/batch_inference_config.example.json
@@ -1,0 +1,25 @@
+{
+  "model_search_roots": [
+    "/exp/dune/data/users/cborden/MLProject/Training_Samples",
+    "/exp/dune/data/users/rrichi/MLProject/Training_Samples",
+    "/exp/dune/data/users/jbarrow/MLProject/Training_Samples"
+  ],
+  "models": [
+    {
+      "name": "Numu_CC_Train_DUNEBeam_Flat_Ar40_p1to10_VectorLeptwNC_eventnum_All_NpNpi_Energy_MAPE_Mom_X_MSE_Mom_Y_MSE_Mom_Z_MSE_Topology_MAE",
+      "training_name": "Numu_CC_Train_DUNEBeam_Flat_Ar40_p1to10_VectorLeptwNC_eventnum_All_NpNpi_Energy_MAPE_Mom_X_MSE_Mom_Y_MSE_Mom_Z_MSE_Topology_MAE"
+    }
+  ],
+  "samples": [
+    {
+      "name": "sample_placeholder",
+      "path": "/path/to/inference/sample.csv"
+    }
+  ],
+  "pairs": [
+    {
+      "model": "Numu_CC_Train_DUNEBeam_Flat_Ar40_p1to10_VectorLeptwNC_eventnum_All_NpNpi_Energy_MAPE_Mom_X_MSE_Mom_Y_MSE_Mom_Z_MSE_Topology_MAE",
+      "sample": "sample_placeholder"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Allow `batch_inference.py` to invoke the ROOT evaluation macro `graph_eval/eval_model.C` for each generated CSV so ROOT outputs (`combined_output.root`, `ellipse_fraction.csv`) and a high-resolution `energy_theta_2d` PNG can be produced and ingested into the runner metadata. 
- Preserve backwards-compatible predictor invocation while extending the batch runner CLI and config parsing to support model discovery by `training_name` and grouped model exports. 

### Description

- Extended `graph_eval/eval_model.C` to accept `output_dir`, `png_path`, and `png_size` parameters, to `mkdir`/`chdir` into the chosen output directory, to save the `energy_theta_2d_canvas` as a PNG at the requested resolution, and to restore the original working directory on exit. 
- Added CLI flags to `transformer_ee/inference/batch_inference.py`: `--eval-macro-path`, `--eval-output-dir`, `--eval-save-png`, `--eval-png-width`, and `--eval-png-height`. 
- Implemented `run_eval_model` in `batch_inference.py` which calls the macro via `subprocess` (`root -l -b -q 'eval_model.C(...)'`), captures the macro return code/output, reads `ellipse_fraction.csv` in the eval output directory, and returns structured metadata placed under the `eval_model` field in each `summary.json` entry. 
- Enhanced pair/config parsing to support `model_search_roots` + `training_name` lookups and to normalize multiple resolved model exports into distinct labeled tasks; preserved predictor compatibility by using `inspect.signature` to only pass supported constructor/`go` kwargs and to fall back when timing metadata or `original_df` are absent. 
- Documented usage in `transformer_ee/inference/README_batch_inference.md` and added a `batch_inference_config.example.json` illustrating `model_search_roots` and `training_name` usage. 

### Testing

- No automated tests were executed for this change. 
- The implementation reports `root` invocation failures in `eval_model` metadata so the runner continues without crashing if `root` is not on `PATH` (behavior exercised in code paths but not covered by automated tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697e361f68832eba9d368f6cb13a42)