### PR TITLE
Handle ENAMETOOLONG for outputs and add resume/skip CLI options

### DIFF
--- a/transformer_ee/inference/configuration_file_tools/CONFIGS_README.md
+++ b/transformer_ee/inference/configuration_file_tools/CONFIGS_README.md
@@ -219,6 +219,7 @@ Fixes:
 - locate the export directory and confirm it contains both `input.json` and `best_model.zip`
 - if necessary, switch from `training_name` resolution to explicit `path` resolution in the config
 - the `batch_inference.py` now supports output for a `models_not_found.txt` which can be saved to the area wherever we output the finished inference samples, allowing for us to go back and retrain if need be if we are somehow missing the `best_model.zip` files storing the model weights. Why this has happened isn't exactly clear, but it can and has happened sadly.
+- if you pass `--missing-models-file` (to skip training names that were already reported missing), the run writes `models_missing_previously.txt` alongside the outputs so you still have a record of which training names were skipped. This keeps `models_not_found.txt` focused on *new* missing exports discovered in the current run.
 
 ### “We got multiple models for one training_name because we accidentally ran over each others training ranges...”
 


### PR DESCRIPTION
### Motivation
- Prevent long model/sample names from causing `OSError: [Errno 36] File name too long` when creating result buckets and files during batch inference.
- Allow long-running batched inference runs to be resumed from a specific task index and to optionally continue past individual task failures while recording the failures for later inspection.
- Avoid repeated expensive training-name lookups for models already recorded as missing by reusing an existing `models_not_found.txt` file when provided.

### Description
- Add filename/path shortening utilities: `shorten_component`, `safe_output_base`, and `ensure_bucket` to sanitize and truncate long components and fall back to a hashed short name when `ENAMETOOLONG` is raised (changes in `transformer_ee/inference/batch_inference.py`).
- Replace direct `output_dir / safe_name(task.model_name)` and unbounded sample basenames with `ensure_bucket(...)` and `safe_output_base(...)` so output directories and CSV/NPZ basenames are length-safe.
- Add CLI options: `--start-task` to skip to a 1-based task index, `--skip-errors` to continue on task failures, and `--missing-models-file` to provide an existing `models_not_found.txt` to skip known-missing training-name lookups.
- Thread the known-missing set into config parsing (`load_pairs_from_config`, `parse_entity`, `parse_pair_entry`, and `resolve_model_from_training_name`) so `training_name` resolutions can be skipped if previously recorded as missing.
- Wrap the per-task execution with try/except to record failures to `failed_tasks.jsonl` (including traceback) when `--skip-errors` is used and optionally re-raise when not.
- Return an `output_bucket` label in the task metadata to record which (possibly shortened/hashed) bucket was used for each task.

### Testing
- No automated tests were executed in this change; the patch was validated via static inspection and a local commit of `transformer_ee/inference/batch_inference.py` (no runtime or unit tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b0cb50dbc832e863cd04697b6e138)