### PR TITLE
Fix eval_model argument ordering in batch inference

### DIFF
--- a/transformer_ee/inference/batch_inference.py
+++ b/transformer_ee/inference/batch_inference.py
@@ -554,11 +554,13 @@ def run_eval_model(
         (
             f"{eval_macro_path}("
             f"\"{csv_path}\","
+            f"false,"
+            f"-1.0,"
             f"\"{eval_output_dir}\","
             f"\"{png_path}\","
             f"{width},"
-            f"{height}"
-            f",\"combined_inference_output.root\""
+            f"{height},"
+            f"\"combined_inference_output.root\""
             f")"
         ),
     ]


### PR DESCRIPTION
### Motivation
- The ROOT macro `eval_model` expects arguments in a different order than previously invoked, causing the macro not to run correctly and preventing generation of `ellipse_fraction.csv` and PNG outputs.

### Description
- Adjusted the `eval_model` invocation in `transformer_ee/inference/batch_inference.py` inside `run_eval_model` so the macro arguments are passed in the expected order (inserted the `false` and `-1.0` parameters and reordered PNG/size/root filename arguments). 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e114f460832eb1935b79a5a6df3b)