### PR TITLE
Add --output-format option to batch_inference to control CSV/NPZ outputs

### DIFF
--- a/transformer_ee/inference/README_batch_inference.md
+++ b/transformer_ee/inference/README_batch_inference.md
@@ -20,6 +20,7 @@ Edit the `model_search_roots`, `models`, `samples`, and `pairs` sections to matc
 python transformer_ee/inference/batch_inference.py \
   --pair-config ./batch_inference_config.json \
   --output-dir ./InferenceTests/Results \
+  --output-format both \
   --device cuda:0
 ```
 
@@ -106,7 +107,8 @@ older predictor implementations.
 
 Outputs include:
 
-- CSV/NPZ outputs per model + sample pair in `--output-dir`.
+- CSV/NPZ outputs per model + sample pair in `--output-dir`. Use `--output-format csv`
+  to write only CSV, or `--output-format npz` for legacy NPZ-only output.
 - `timings.csv` for per-batch timing.
 - `summary.json` with metadata for each task.
 


### PR DESCRIPTION
### Motivation

- Provide a CLI switch to control whether per-task outputs write both CSV and NPZ (current default), only CSV (to save space and drive `eval_model.C`), or only NPZ (legacy behavior for older tools).
- Ensure the optional ROOT-based evaluation (`--eval-macro-path`) is only used when a CSV is produced.

### Description

- Added a new CLI flag `--output-format` with choices `"both"`, `"csv"`, and `"npz"` and default `"both"` to `batch_inference.py`.
- Threaded `output_format` into `run_task` and implemented `save_csv`/`save_npz` branching so outputs are written only when requested, and `summary.json` metadata now sets `output_csv`/`output_npz` to `None` when omitted.
- Guarded `--eval-macro-path` so it raises a helpful `ValueError` if evaluation is requested but CSV output is disabled.
- Updated `transformer_ee/inference/README_batch_inference.md` quick-start and Outputs section to document the new flag and usage patterns.

### Testing

- No automated tests were executed for this change.
- Changes were validated via static inspection and local edits to `batch_inference.py` and the README, and a commit was created.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69813c96ea5c832eb94cedb7beeb08ba)