### PR TITLE
Improve eval_model logging and PNG placement

### DIFF
--- a/transformer_ee/inference/README_batch_inference.md
+++ b/transformer_ee/inference/README_batch_inference.md
@@ -116,7 +116,7 @@ Outputs include:
 
 You can optionally run the ROOT macro `graph_eval/eval_model.C` for each generated
 CSV to produce `combined_inference_output.root` and `ellipse_fraction.csv`, and to
-save the energy/theta 2D canvas as a PNG.
+save the energy/theta 2D canvas as a PNG alongside each per-model output CSV.
 
 Example:
 
@@ -132,5 +132,7 @@ python transformer_ee/inference/batch_inference.py \
 ```
 
 When enabled, the `summary.json` entries include an `eval_model` section with the
-macro path, output directory, optional PNG path, and any matching row from
-`ellipse_fraction.csv` (matched against the per-task model label).
+macro path, output directory, optional PNG path, `stdout`/`stderr` from the macro,
+and any matching row from `ellipse_fraction.csv` (matched against the per-task
+model label). If ROOT fails to execute the macro, `eval_model.error` will explain
+why.

--- a/transformer_ee/inference/batch_inference.py
+++ b/transformer_ee/inference/batch_inference.py
@@ -550,10 +550,20 @@ def run_eval_model(
     eval_png_size: Optional[Tuple[int, int]],
 ) -> Dict[str, object]:
     eval_output_dir.mkdir(parents=True, exist_ok=True)
+    if not eval_macro_path.exists():
+        return {
+            "macro_path": str(eval_macro_path),
+            "output_dir": str(eval_output_dir),
+            "png_path": None,
+            "returncode": None,
+            "ellipse_fraction": None,
+            "model_label": model_label,
+            "error": f"eval macro not found at {eval_macro_path}",
+        }
     png_path = ""
     if eval_save_png:
         png_base = f"{safe_name(model_name)}__{safe_name(csv_path.stem)}__energy_theta_2d.png"
-        png_path = str((eval_output_dir / png_base).resolve())
+        png_path = str((csv_path.parent / png_base).resolve())
     width, height = eval_png_size or (0, 0)
     cmd = [
         "root",
@@ -580,6 +590,8 @@ def run_eval_model(
         "returncode": None,
         "ellipse_fraction": None,
         "model_label": model_label,
+        "stdout": None,
+        "stderr": None,
     }
     try:
         completed = subprocess.run(
@@ -592,8 +604,10 @@ def run_eval_model(
         result["error"] = "root command not found on PATH"
         return result
     result["returncode"] = completed.returncode
+    result["stdout"] = completed.stdout.strip()
+    result["stderr"] = completed.stderr.strip()
     if completed.returncode != 0:
-        result["error"] = completed.stderr.strip() or completed.stdout.strip()
+        result["error"] = result["stderr"] or result["stdout"]
         return result
 
     ellipse_path = eval_output_dir / "ellipse_fraction.csv"
@@ -688,6 +702,7 @@ def run_task(
         print(f"[INFO] Saved predictions to {npz_path}")
     eval_meta: Dict[str, object] = {}
     if eval_macro_path is not None:
+        print(f"[INFO] Running eval macro for {csv_path}")
         eval_meta = run_eval_model(
             csv_path=csv_path,
             model_name=task.model_name,
@@ -697,6 +712,11 @@ def run_task(
             eval_save_png=eval_save_png,
             eval_png_size=eval_png_size,
         )
+        if eval_meta.get("error"):
+            print(
+                "[WARN] eval_model failed for "
+                f"{csv_path}: {eval_meta.get('error')}"
+            )
     total_time = 0.0
     if batch_times:
         total_time = record_batch_timings(

--- a/transformer_ee/inference/batch_inference.py
+++ b/transformer_ee/inference/batch_inference.py
@@ -558,6 +558,8 @@ def run_eval_model(
             "returncode": None,
             "ellipse_fraction": None,
             "model_label": model_label,
+            "stdout": None,
+            "stderr": None,
             "error": f"eval macro not found at {eval_macro_path}",
         }
     png_path = ""


### PR DESCRIPTION
### Motivation
- Users could not see why the ROOT `eval_model.C` macro appeared to not run because failures and macro stdout/stderr were not reported and PNGs were written to the top-level eval directory instead of next to each output CSV.
- The runner should validate the macro path and provide immediate, actionable diagnostics when ROOT or the macro fails.

### Description
- Add a check that `--eval-macro-path` exists and return a clear `eval_model.error` when the macro file is missing by validating `eval_macro_path.exists()` in `run_eval_model`.
- Save the per-task PNG next to the per-model CSV by computing `png_path` from `csv_path.parent` so the `energy_theta_2d.png` appears in each model's output folder.
- Capture `stdout` and `stderr` from the `root` subprocess and include them in the `eval_model` metadata returned by `run_eval_model`, and print an info/warning message from `run_task` when the macro is run or fails.
- Update `transformer_ee/inference/README_batch_inference.md` to document the PNG placement and that `summary.json` now contains `stdout`/`stderr` and `eval_model.error` for macro failures.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698155991578832ebb530b4c02cab829)