### PR TITLE
Add beam_mode toggle to batch inference eval runner

### DIFF
--- a/transformer_ee/inference/README_batch_inference.md
+++ b/transformer_ee/inference/README_batch_inference.md
@@ -126,6 +126,7 @@ python transformer_ee/inference/batch_inference.py \
   --output-dir ./InferenceTests/Results \
   --eval-macro-path ./graph_eval/eval_model.C \
   --eval-output-dir ./InferenceTests/Results \
+  --beam-mode true \
   --eval-save-png \
   --eval-png-width 3000 \
   --eval-png-height 2000
@@ -136,3 +137,6 @@ macro path, output directory, optional PNG path, `stdout`/`stderr` from the macr
 and any matching row from `ellipse_fraction.csv` (matched against the per-task
 model label). If ROOT fails to execute the macro, `eval_model.error` will explain
 why.
+
+Use `--beam-mode true` for beam-neutrino plots with narrowed ranges, or
+`--beam-mode false` (the default) for atmospheric-style ranges.

--- a/transformer_ee/inference/configuration_file_tools/CONFIGS_README.md
+++ b/transformer_ee/inference/configuration_file_tools/CONFIGS_README.md
@@ -188,8 +188,11 @@ python3 transformer_ee/inference/batch_inference.py   --pair-config batch_infere
 If we want a ROOT-based plotting + ellipse (basic 2D performance metric) evaluation per output:
 
 ```bash
-python3 transformer_ee/inference/batch_inference.py   --pair-config batch_inference_config.DUNEAtmFlat-to-DUNEAtmNat.json   --output-dir /exp/dune/data/users/$USER/MLProject/Inference_Samples/HondaDUNEOsc/Results   --device cuda:0   --eval-macro-path ./graph_eval/eval_model.C   --eval-output-dir /exp/dune/data/users/$USER/MLProject/Inference_Samples/HondaDUNEOsc/Results   --eval-save-png   --eval-png-width 3000   --eval-png-height 2000
+python3 transformer_ee/inference/batch_inference.py   --pair-config batch_inference_config.DUNEAtmFlat-to-DUNEAtmNat.json   --output-dir /exp/dune/data/users/$USER/MLProject/Inference_Samples/HondaDUNEOsc/Results   --device cuda:0   --eval-macro-path ./graph_eval/eval_model.C   --eval-output-dir /exp/dune/data/users/$USER/MLProject/Inference_Samples/HondaDUNEOsc/Results   --beam-mode false   --eval-save-png   --eval-png-width 3000   --eval-png-height 2000
 ```
+
+For beam-neutrino inference, pass `--beam-mode true` to apply the narrowed
+plotting ranges in `eval_model.C`.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Provide a way to select the `beam_mode` flag when invoking the ROOT `eval_model.C` macro from the batch inference runner so plotting ranges can be tailored for beam (narrow) vs atmospheric (wide) studies without changing `eval_model.C`.
- Keep `eval_model.C` unchanged and only extend the Python runner to pass the correct boolean argument to the macro and document the option.

### Description
- Add a new CLI argument `--beam-mode` (choices `true|false`, default `false`) to `transformer_ee/inference/batch_inference.py` and parse it in `main()`.
- Thread the boolean through `run_task()` into `run_eval_model()` and update the generated ROOT command so the macro receives the `beam_mode` value instead of the previous hardcoded `false` value.
- Update documentation examples in `transformer_ee/inference/README_batch_inference.md` and `transformer_ee/inference/configuration_file_tools/CONFIGS_README.md` to show `--beam-mode` usage and explain when to use `true` vs `false`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983bb7cd114832ebd9e86617a1a6edb)