### PR TITLE
Improve batch inference config generation for beam variants

### DIFF
--- a/transformer_ee/inference/configuration_file_tools/CONFIGS_README.md
+++ b/transformer_ee/inference/configuration_file_tools/CONFIGS_README.md
@@ -20,10 +20,16 @@ We provide lists like:
 - `Train_DUNEBeam_Flat_Models_rrich.txt`
 - `Train_DUNEBeam_Flat_Models_cborden.txt`
 - `Train_DUNEBeam_Flat_Models_jbarrow.txt`
+- `Train_DUNEBeam_Nat_Models_rrichi.txt`
+- `Train_DUNEBeam_Nat_Models_cborden.txt`
+- `Train_DUNEBeam_Nat_Models_jbarrow.txt`
+- `Train_NOvABeam_Nat_Models_rrichi.txt`
+- `Train_NOvABeam_Nat_Models_cborden.txt`
+- `Train_NOvABeam_Nat_Models_jbarrow.txt`
 
-Each file contains many lines/model names returned from a simple `ls` command; the generator extracts the *trained model training names* (strings starting at the moment with `Numu_CC_Train_...`) and filters to **Flat-trained** subsets:
-- Current atmospheric configs: require `DUNEAtmo_Flat`
-- Current beam configs: require `DUNEBeam_Flat`
+Each file contains many lines/model names returned from a simple `ls` command; the generator extracts the *trained model training names* (strings starting at the moment with `Numu_CC_Train_...`) and then filters/splits as needed:
+- Atmospheric configs are filtered by optional substring lists (see `--atm-require-substrs`)
+- Beam configs are separated into flat vs natural (and DUNE vs NOvA) based on training-name tokens
 
 The tool then deduplicates across all provided lists.
 
@@ -40,6 +46,9 @@ The generator currently writes out configuration files pertinent to flat atmosph
 2. `batch_inference_config.DUNEBeamFlat-to-DUNEFDBeamOsc.json`
 3. `batch_inference_config.DUNEBeamFlat-to-DUNEND39mOffAxisBeamNat.json`
 4. `batch_inference_config.DUNEBeamFlat-to-DUNENDBeamNat.json`
+5. `batch_inference_config.DUNEBeamNat-to-DUNEFDBeamOsc.json`
+6. `batch_inference_config.DUNEBeamNat-to-DUNEND39mOffAxisBeamNat.json`
+7. `batch_inference_config.NOvABeamNat-to-NOvAFDBeamOsc.json`
 
 ---
 
@@ -107,6 +116,9 @@ The current inference sample paths in that file correspond to:
 4. DUNE-like Beam Natural Spectra, OnAxis ND and so unoscillated (p1to6 = 0.1 - 6 GeV of incoming neutrino energy):
 - Vector + Scalar in `/exp/dune/data/users/rrichi/MLProject/Training_Samples/Beam_Like/Natural_Spectra/DUNEOnAxisND/`
 
+5. NOvA-like Beam Natural Spectra, OnAxis FD Oscillated:
+- Vector + Scalar in `/exp/dune/data/users/rrichi/MLProject/Training_Samples/Beam_Like/Natural_Spectra/NOvAFDOsc/`
+
 Note that some/all of these are under Richi's `Training_Samples` area -- while it is true they were used for training, because they are statistically independent than the flat spectra, we can use them for inference purposes without issue, while also guaranteeing that we have high statistics for inference-related performance plots.
 
 If we move samples or want different ones, edit only the paths in this dictionary—no other logic changes needed.
@@ -153,7 +165,7 @@ If they are not in the current working directory, either:
 ./make_batch_inference_configs.sh
 ```
 
-This writes the (currently four) JSON files into the current directory (or the configured output dir).
+This writes the (currently seven) JSON files into the current directory (or the configured output dir).
 
 ### Re-running behavior (backups)
 

--- a/transformer_ee/inference/configuration_file_tools/make_batch_inference_configs.sh
+++ b/transformer_ee/inference/configuration_file_tools/make_batch_inference_configs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This wrapper assumes the 6 input text files are in the current directory.
+# This wrapper assumes the expected input text files are in the current directory.
 # Edit the arrays below if your filenames/locations differ.
 
 ATM_FILES=(
@@ -28,9 +28,15 @@ NOVA_BEAM_NAT_FILES=(
   "Train_NOvABeam_Nat_Models_cborden.txt"
 )
 
+BEAM_FILES=(
+  "${DUNE_BEAM_FLAT_FILES[@]}"
+  "${DUNE_BEAM_NAT_FILES[@]}"
+  "${NOVA_BEAM_NAT_FILES[@]}"
+)
+
 OUTDIR="."
 
 python3 generate_batch_inference_configs.py \
-#  --outdir "${OUTDIR}" \
-#  --atm-files "${ATM_FILES[@]}" \
-  --beam-files "${DUNE_BEAM_NAT_FILES[@]}"
+  --outdir "${OUTDIR}" \
+  --atm-files "${ATM_FILES[@]}" \
+  --beam-files "${BEAM_FILES[@]}"


### PR DESCRIPTION
### Motivation
- Allow generating batch inference configs that compare models trained on natural vs flat spectra and to run inference across different beam-family samples (DUNE vs NOvA).
- Make the substring matching and `specs` selection more flexible so lists like `Train_DUNEBeam_Nat...` and `Train_NOvABeam_Nat...` can be used alongside flat-training lists.
- Provide CLI options and defaults so `make_batch_inference_configs.sh` and the generator work out-of-the-box with the expanded set of model-list files.

### Description
- Updated `generate_batch_inference_configs.py` to accept multiple required substrings via `--atm-require-substrs` and `--beam-require-substrs` and changed `_extract_training_names()` to apply all provided substrings. 
- Added helpers `_spectrum_kind()`, `_beam_family()`, and `_filter_models()` and used them to split beam models into DUNE flat, DUNE natural, and NOvA natural collections and to populate the `specs` map accordingly. 
- Expanded the default `--beam-files` list to include DUNE flat, DUNE nat, and NOvA nat text files and added warnings when expected categories are absent. 
- Updated `make_batch_inference_configs.sh` to combine beam file groups into `BEAM_FILES` and to call the Python generator with both `--atm-files` and `--beam-files` by default. 
- Revised `CONFIGS_README.md` to document the new sample coverage, additional output configs (now seven), and the new CLI filtering options.

### Testing
- No automated tests were run for these documentation/configuration changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988dcd91eb4832e8c11e751dfe322f9)