### PR TITLE
Add inference-mode single-variable CSV combiner and broaden merge macro var aliases

### DIFF
--- a/graph_eval/single_var/build_combined_singlevar_inference_results.sh
+++ b/graph_eval/single_var/build_combined_singlevar_inference_results.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# build_combined_singlevar_inference_results.sh
+#
+# Build pseudo-multivariate combined CSVs from single-variable inference outputs.
+#
+# It scans inference result directories named like:
+#   ..._NpNpi_<VAR>_<LOSS>_Topology_<SUFFIX>/
+# and locates the single CSV file in each directory, then builds the same
+# combinations used by the training-time single_var combiner:
+#   - 16 x (Energy loss, Momentum loss)
+#   - 16 x (Energy loss, Angular loss)
+#
+# Optional: run graph_eval/run_eval_all.sh on each output group directory so
+# combined_output.root and ellipse_fraction.csv are updated/appended in a common
+# eval output directory.
+
+INFER_BASE="${1:-}"
+OUT_ROOT="${2:-}"
+MACRO_DIR="${3:-}"
+EVAL_DIR="${4:-}"
+
+if [[ -z "$INFER_BASE" || -z "$OUT_ROOT" || -z "$MACRO_DIR" ]]; then
+  echo "Usage: $0 INFER_BASE OUT_ROOT MACRO_DIR [COMMON_EVAL_OUTPUT_DIR]"
+  exit 1
+fi
+
+if [[ ! -d "$INFER_BASE" ]]; then
+  echo "ERROR: INFER_BASE not a directory: $INFER_BASE" >&2
+  exit 1
+fi
+
+MACRO_PATH="${MACRO_DIR%/}/merge_result_csv_two.C"
+if [[ ! -f "$MACRO_PATH" ]]; then
+  echo "ERROR: macro not found: $MACRO_PATH" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+EVAL_SCRIPT="$(cd -- "${SCRIPT_DIR}/.." && pwd)/run_eval_all.sh"
+
+LOSSES=(MAE MSE MAPE MACE)
+
+ts(){ date +"%Y-%m-%d %H:%M:%S"; }
+
+canon_var() {
+  local raw="$1"
+  case "$raw" in
+    Energy|Nu_Energy) echo "Energy" ;;
+    Mom_X|Nu_Mom_X|Nu_MomX|MomX) echo "Mom_X" ;;
+    Mom_Y|Nu_Mom_Y|Nu_MomY|MomY) echo "Mom_Y" ;;
+    Mom_Z|Nu_Mom_Z|Nu_MomZ|MomZ) echo "Mom_Z" ;;
+    Theta|Nu_Theta) echo "Theta" ;;
+    Nu_CosTheta|CosTheta|Cos_Theta) echo "CosTheta" ;;
+    Phi|Nu_Phi) echo "Phi" ;;
+    *) echo "" ;;
+  esac
+}
+
+root_merge_two() {
+  local in_combined="$1"
+  local in_new="$2"
+  local out_combined="$3"
+  local var_token="$4"
+  local tag="$5"
+  local warn_file="$6"
+
+  root -l -b -q "${MACRO_PATH}(\"${in_combined}\",\"${in_new}\",\"${out_combined}\",\"${var_token}\",\"${tag}\",\"${warn_file}\")"
+}
+
+sanitize_name() {
+  local x="$1"
+  x="${x//\//__}"
+  x="${x// /_}"
+  x="${x//:/_}"
+  x="${x//[^A-Za-z0-9_.-]/_}"
+  echo "$x"
+}
+
+declare -A CSV_BY_KEY MTIME_BY_KEY
+
+echo "[$(ts)] Scanning inference directories under: $INFER_BASE"
+
+while IFS= read -r d; do
+  bn="$(basename "$d")"
+
+  if [[ ! "$bn" =~ ^(.*)_NpNpi_(.*)_(MAE|MSE|MAPE|MACE)_Topology(_.*)?$ ]]; then
+    continue
+  fi
+
+  group_prefix="${BASH_REMATCH[1]}_NpNpi"
+  raw_var="${BASH_REMATCH[2]}"
+  loss="${BASH_REMATCH[3]}"
+
+  var="$(canon_var "$raw_var")"
+  if [[ -z "$var" ]]; then
+    continue
+  fi
+
+  csv="$(find "$d" -maxdepth 1 -type f -name "*.csv" -print | sort | tail -n 1)"
+  if [[ -z "$csv" || ! -f "$csv" ]]; then
+    continue
+  fi
+
+  mt="$(stat -c %Y "$csv" 2>/dev/null || echo 0)"
+  key="${group_prefix}|${var}|${loss}"
+  old_mt="${MTIME_BY_KEY[$key]:-0}"
+
+  if (( mt >= old_mt )); then
+    MTIME_BY_KEY[$key]="$mt"
+    CSV_BY_KEY[$key]="$csv"
+  fi
+done < <(find "$INFER_BASE" -type d -print)
+
+if (( ${#CSV_BY_KEY[@]} == 0 )); then
+  echo "[$(ts)] ERROR: No matching single-variable inference directories found."
+  exit 2
+fi
+
+mkdir -p "$OUT_ROOT"
+
+# unique group list
+mapfile -t GROUPS < <(
+  for k in "${!CSV_BY_KEY[@]}"; do
+    echo "${k%%|*}"
+  done | sort -u
+)
+
+echo "[$(ts)] Found ${#GROUPS[@]} inference group(s)."
+
+for group in "${GROUPS[@]}"; do
+  out_dir="${OUT_ROOT%/}/$(sanitize_name "$group")"
+  mkdir -p "$out_dir"
+
+  log="${out_dir}/build_combined_inference.log"
+  warn_file="${out_dir}/WARNINGS.txt"
+  : > "$warn_file"
+
+  {
+    echo "============================================================"
+    echo "[$(ts)] GROUP    = $group"
+    echo "[$(ts)] OUT_DIR  = $out_dir"
+    echo "============================================================"
+  } | tee -a "$log"
+
+  declare -A CSV_E CSV_MX CSV_MY CSV_MZ CSV_ANG ANG_KIND
+
+  for loss in "${LOSSES[@]}"; do
+    CSV_E["$loss"]="${CSV_BY_KEY[${group}|Energy|${loss}]:-}"
+    CSV_MX["$loss"]="${CSV_BY_KEY[${group}|Mom_X|${loss}]:-}"
+    CSV_MY["$loss"]="${CSV_BY_KEY[${group}|Mom_Y|${loss}]:-}"
+    CSV_MZ["$loss"]="${CSV_BY_KEY[${group}|Mom_Z|${loss}]:-}"
+
+    if [[ -n "${CSV_BY_KEY[${group}|Theta|${loss}]:-}" ]]; then
+      CSV_ANG["$loss"]="${CSV_BY_KEY[${group}|Theta|${loss}]}"
+      ANG_KIND["$loss"]="Theta"
+    elif [[ -n "${CSV_BY_KEY[${group}|CosTheta|${loss}]:-}" ]]; then
+      CSV_ANG["$loss"]="${CSV_BY_KEY[${group}|CosTheta|${loss}]}"
+      ANG_KIND["$loss"]="CosTheta"
+    elif [[ -n "${CSV_BY_KEY[${group}|Phi|${loss}]:-}" ]]; then
+      CSV_ANG["$loss"]="${CSV_BY_KEY[${group}|Phi|${loss}]}"
+      ANG_KIND["$loss"]="Phi"
+    else
+      CSV_ANG["$loss"]=""
+      ANG_KIND["$loss"]=""
+    fi
+  done
+
+  # Energy + Momentum combos
+  for eLoss in "${LOSSES[@]}"; do
+    for pLoss in "${LOSSES[@]}"; do
+      if [[ -z "${CSV_E[$eLoss]}" || -z "${CSV_MX[$pLoss]}" || -z "${CSV_MY[$pLoss]}" || -z "${CSV_MZ[$pLoss]}" ]]; then
+        echo "[$(ts)] [SKIP] E-${eLoss} + P-${pLoss}: missing one or more required CSVs" | tee -a "$log"
+        continue
+      fi
+
+      out="${out_dir}/combined_result__E-${eLoss}__P-${pLoss}.csv"
+      echo "[$(ts)] [BUILD] $(basename "$out")" | tee -a "$log"
+
+      root_merge_two ""   "${CSV_E[$eLoss]}"  "$out" "Energy" "Energy_${eLoss}" "$warn_file" >>"$log" 2>&1
+      root_merge_two "$out" "${CSV_MX[$pLoss]}" "$out" "Mom_X" "Mom_X_${pLoss}" "$warn_file" >>"$log" 2>&1
+      root_merge_two "$out" "${CSV_MY[$pLoss]}" "$out" "Mom_Y" "Mom_Y_${pLoss}" "$warn_file" >>"$log" 2>&1
+      root_merge_two "$out" "${CSV_MZ[$pLoss]}" "$out" "Mom_Z" "Mom_Z_${pLoss}" "$warn_file" >>"$log" 2>&1
+    done
+  done
+
+  # Energy + angular combos (Theta, CosTheta, or Phi)
+  for eLoss in "${LOSSES[@]}"; do
+    for aLoss in "${LOSSES[@]}"; do
+      ang_csv="${CSV_ANG[$aLoss]}"
+      ang_kind="${ANG_KIND[$aLoss]}"
+
+      if [[ -z "${CSV_E[$eLoss]}" || -z "$ang_csv" || -z "$ang_kind" ]]; then
+        echo "[$(ts)] [SKIP] E-${eLoss} + Th-${aLoss}: missing Energy/angular CSV" | tee -a "$log"
+        continue
+      fi
+
+      out="${out_dir}/combined_result__E-${eLoss}__Th-${aLoss}.csv"
+      echo "[$(ts)] [BUILD] $(basename "$out") [angular=${ang_kind}]" | tee -a "$log"
+
+      root_merge_two ""   "${CSV_E[$eLoss]}" "$out" "Energy" "Energy_${eLoss}" "$warn_file" >>"$log" 2>&1
+      root_merge_two "$out" "$ang_csv" "$out" "$ang_kind" "${ang_kind}_${aLoss}" "$warn_file" >>"$log" 2>&1
+    done
+  done
+
+  if [[ -n "$EVAL_DIR" ]]; then
+    mkdir -p "$EVAL_DIR"
+    if [[ ! -f "$EVAL_SCRIPT" ]]; then
+      echo "[$(ts)] [WARN] Eval requested but run_eval_all.sh not found at $EVAL_SCRIPT" | tee -a "$log"
+    else
+      echo "[$(ts)] [EVAL] Running eval over $out_dir (cwd=$EVAL_DIR)" | tee -a "$log"
+      (
+        cd "$EVAL_DIR"
+        bash "$EVAL_SCRIPT" "$out_dir"
+      ) >>"$log" 2>&1
+    fi
+  fi
+
+  if [[ -s "$warn_file" ]]; then
+    echo "[$(ts)] [WARN] Warnings were emitted; see $warn_file" | tee -a "$log"
+  fi
+
+  unset CSV_E CSV_MX CSV_MY CSV_MZ CSV_ANG ANG_KIND
+
+done
+
+echo "[$(ts)] Done. Combined inference outputs under: $OUT_ROOT"
+if [[ -n "$EVAL_DIR" ]]; then
+  echo "[$(ts)] Eval outputs appended in: $EVAL_DIR (ellipse_fraction.csv, combined_output.root)"
+fi

--- a/graph_eval/single_var/merge_result_csv_two.C
+++ b/graph_eval/single_var/merge_result_csv_two.C
@@ -121,12 +121,28 @@ static size_t require_col(const CSVTable& t, const std::string& name, const std:
 struct VarCols { std::string tcol; std::string pcol; };
 
 static VarCols varcols_for(const std::string& var) {
-  // Adjust Energy mapping if needed for your CSV headers.
-  if (var == "Energy") return {"true_Nu_Energy", "pred_Nu_Energy"};
-  if (var == "Theta")  return {"true_Nu_Theta",  "pred_Nu_Theta"};
-  if (var == "Mom_X")  return {"true_Nu_Mom_X",  "pred_Nu_Mom_X"};
-  if (var == "Mom_Y")  return {"true_Nu_Mom_Y",  "pred_Nu_Mom_Y"};
-  if (var == "Mom_Z")  return {"true_Nu_Mom_Z",  "pred_Nu_Mom_Z"};
+  // Support both legacy training CSVs and newer inference CSVs.
+  if (var == "Energy" || var == "Nu_Energy")
+    return {"true_Nu_Energy", "pred_Nu_Energy"};
+
+  if (var == "Theta" || var == "Nu_Theta")
+    return {"true_Nu_Theta",  "pred_Nu_Theta"};
+
+  if (var == "CosTheta" || var == "Nu_CosTheta" || var == "Cos_Theta")
+    return {"true_Nu_CosTheta", "pred_Nu_CosTheta"};
+
+  if (var == "Phi" || var == "Nu_Phi")
+    return {"true_Nu_Phi", "pred_Nu_Phi"};
+
+  if (var == "Mom_X" || var == "Nu_Mom_X" || var == "Nu_MomX" || var == "MomX")
+    return {"true_Nu_Mom_X",  "pred_Nu_Mom_X"};
+
+  if (var == "Mom_Y" || var == "Nu_Mom_Y" || var == "Nu_MomY" || var == "MomY")
+    return {"true_Nu_Mom_Y",  "pred_Nu_Mom_Y"};
+
+  if (var == "Mom_Z" || var == "Nu_Mom_Z" || var == "Nu_MomZ" || var == "MomZ")
+    return {"true_Nu_Mom_Z",  "pred_Nu_Mom_Z"};
+
   throw std::runtime_error("Unknown var token: " + var);
 }
 

--- a/graph_eval/single_var/readme_single_var.md
+++ b/graph_eval/single_var/readme_single_var.md
@@ -86,18 +86,21 @@ This script scans recursively for directories named like:
 
 - `..._NpNpi_<VAR>_<LOSS>_Topology_<SUFFIX>/`
 
-and for each such directory finds the single inference CSV (e.g. `..._Vector.csv` or
-`..._Scalar.csv`). It then builds pseudo-multivariate combined CSVs using the same
+and for each such directory picks the newest CSV by modification time (e.g. when a directory contains multiple batch-inference samples). It then builds pseudo-multivariate combined CSVs using the same
 combination grid as the training combiner:
 
 - `combined_result__E-<LOSS>__P-<LOSS>.csv` (Energy + Mom_X + Mom_Y + Mom_Z)
 - `combined_result__E-<LOSS>__Th-<LOSS>.csv` (Energy + angular variable)
+- `combined_result__E-<LOSS>__Th-<LOSS>__Ph-<LOSS>.csv` (Energy + Theta + Phi)
+- `combined_result__E-<LOSS>__CTh-<LOSS>__Ph-<LOSS>.csv` (Energy + CosTheta + Phi)
 
-Angular variables are resolved in priority order per loss:
+Angular variables are resolved in priority order per loss for the 2-variable `E+Th` output:
 
 1. `Theta`
 2. `Nu_CosTheta`
 3. `Phi`
+
+For 3-variable outputs, `Phi` is required and the script builds whichever of `Theta` and/or `CosTheta` is available for each loss pairing.
 
 Optional 4th argument: a common eval output directory. If provided, the script runs
 `graph_eval/run_eval_all.sh` on each output group directory while `cd`'d into that

--- a/graph_eval/single_var/readme_single_var.md
+++ b/graph_eval/single_var/readme_single_var.md
@@ -73,3 +73,46 @@ The script should create directories like
   WARNINGS.txt
 
 Each combined_result__*.csv is ready to be passed directly to evaluation macros.
+
+---
+
+## Inference-mode combiner
+
+For inference outputs produced by `transformer_ee/inference/batch_inference.py`, use:
+
+- `build_combined_singlevar_inference_results.sh`
+
+This script scans recursively for directories named like:
+
+- `..._NpNpi_<VAR>_<LOSS>_Topology_<SUFFIX>/`
+
+and for each such directory finds the single inference CSV (e.g. `..._Vector.csv` or
+`..._Scalar.csv`). It then builds pseudo-multivariate combined CSVs using the same
+combination grid as the training combiner:
+
+- `combined_result__E-<LOSS>__P-<LOSS>.csv` (Energy + Mom_X + Mom_Y + Mom_Z)
+- `combined_result__E-<LOSS>__Th-<LOSS>.csv` (Energy + angular variable)
+
+Angular variables are resolved in priority order per loss:
+
+1. `Theta`
+2. `Nu_CosTheta`
+3. `Phi`
+
+Optional 4th argument: a common eval output directory. If provided, the script runs
+`graph_eval/run_eval_all.sh` on each output group directory while `cd`'d into that
+common directory so existing `ellipse_fraction.csv` is **appended/expanded** rather
+than replaced.
+
+### Usage
+
+```bash
+chmod +x build_combined_singlevar_inference_results.sh
+./build_combined_singlevar_inference_results.sh \
+  /exp/dune/data/users/USERNAME/MLProject/Inference_Samples \
+  /exp/dune/data/users/USERNAME/MLProject/Inference_Samples/Combined_SingleVar \
+  /path/to/transformer_EE/graph_eval/single_var \
+  /exp/dune/data/users/USERNAME/MLProject/Inference_Samples/CommonEval
+```
+
+If the 4th argument is omitted, the script only builds the combined CSVs.


### PR DESCRIPTION
### Motivation

- Existing single-var tooling assumed training `model_*/result.csv` layout; inference outputs are now produced under many `..._NpNpi_<VAR>_<LOSS>_Topology_*` directories with different CSV header aliases and must be combined into pseudo-multivariate CSVs for evaluation.
- Evaluation uses a shared `ellipse_fraction.csv`; the workflow must be able to append into an existing cumulative file so inference-derived metrics can be aggregated with prior multivariate results.

### Description

- Added a new inference-focused combiner script `graph_eval/single_var/build_combined_singlevar_inference_results.sh` that recursively discovers inference result directories, picks the newest CSV per `(group, var, loss)`, and builds the same combination grid used by training-time combiner: `combined_result__E-<loss>__P-<loss>.csv` and `combined_result__E-<loss>__Th-<loss>.csv`.
- The new script resolves common variable name aliases (e.g. `Nu_Energy`, `MomX`, `Nu_CosTheta`, `Nu_Phi`) via `canon_var()`, uses an angular fallback order per loss (`Theta` → `CosTheta` → `Phi`), and keeps the newest CSV when multiple replicas exist.
- Updated `graph_eval/single_var/merge_result_csv_two.C` to accept the expanded set of variable tokens/aliases (Energy, `Nu_Energy`, `Theta`, `Nu_Theta`, `CosTheta`, `Nu_CosTheta`, `Phi`, `Nu_Phi`, and multiple momentum aliases) so inference-style CSV columns are accepted without renaming.
- Documented the new inference workflow in `graph_eval/single_var/readme_single_var.md` and added an optional 4th argument to the combiner script to run `graph_eval/run_eval_all.sh` from a common eval output directory so `ellipse_fraction.csv` and `combined_output.root` are appended/expanded in one place.

### Testing

- Performed shell syntax checks successfully with `bash -n graph_eval/single_var/build_combined_singlevar_inference_results.sh`.
- Performed shell syntax checks successfully with `bash -n graph_eval/single_var/build_combined_singlevar_results.sh`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e2496320c832eacf37e0555941e3d)