### PR TITLE
Fix silent exit in singlevar inference combiner

### DIFF
--- a/graph_eval/single_var/build_combined_singlevar_inference_results.sh
+++ b/graph_eval/single_var/build_combined_singlevar_inference_results.sh
@@ -44,7 +44,7 @@ LOSSES=(MAE MSE MAPE MACE)
 
 ts(){ date +"%Y-%m-%d %H:%M:%S"; }
 
-trap 'rc=$?; echo "[$(ts)] ERROR: command failed (exit=${rc}) at line ${BASH_LINENO[0]}: ${BASH_COMMAND}" >&2' ERR
+trap 'rc=$?; line="${BASH_LINENO[0]-$LINENO}"; cmd="${BASH_COMMAND-UNKNOWN}"; echo "[$(ts)] ERROR: command failed (exit=${rc}) at line ${line}: ${cmd}" >&2' ERR
 
 canon_var() {
   local raw="$1"

--- a/graph_eval/single_var/build_combined_singlevar_inference_results.sh
+++ b/graph_eval/single_var/build_combined_singlevar_inference_results.sh
@@ -44,6 +44,8 @@ LOSSES=(MAE MSE MAPE MACE)
 
 ts(){ date +"%Y-%m-%d %H:%M:%S"; }
 
+trap 'rc=$?; echo "[$(ts)] ERROR: command failed (exit=${rc}) at line ${BASH_LINENO[0]}: ${BASH_COMMAND}" >&2' ERR
+
 canon_var() {
   local raw="$1"
   case "$raw" in
@@ -162,7 +164,11 @@ fi
 mkdir -p "$OUT_ROOT"
 
 # unique group list
-mapfile -t GROUPS < <(
+GROUPS=()
+while IFS= read -r g; do
+  [[ -n "$g" ]] || continue
+  GROUPS+=("$g")
+done < <(
   for k in "${!CSV_BY_KEY[@]}"; do
     echo "${k%%|*}"
   done | sort -u


### PR DESCRIPTION
### Motivation
- The single-var combiner script could terminate after the scan phase without emitting an error or output, likely due to an unreported command failure under `set -euo pipefail` and brittle use of `mapfile` for building the group list.

### Description
- Add an `ERR` trap near the top of `graph_eval/single_var/build_combined_singlevar_inference_results.sh` to log the failing command, its exit code, and line number when an error occurs.
- Replace the `mapfile -t GROUPS` usage with a portable `while IFS= read -r` collector that explicitly builds the `GROUPS` array from the unique keys in `CSV_BY_KEY`.

### Testing
- Performed a syntax check with `bash -n graph_eval/single_var/build_combined_singlevar_inference_results.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e5b8b5c24832eb93dbee84499a1c3)