### PR TITLE
Rename bestscore to best_val_loss_sentinel; add robust checkpointing and CLI early-stopping

### DIFF
--- a/CLI_launch_example.txt
+++ b/CLI_launch_example.txt
@@ -22,6 +22,6 @@ python3 train_wide.py \
 The full set of optional arguments and their default values when not called explicitly can be found in train_wide.py
 
 Notes:
-- `--early-stop-window` enables early stopping on trailing-window percent validation-loss improvement.
+- `--early-stop-window` enables early stopping on trailing-window percent validation-loss improvement and must be set to at least `2`.
 - `--early-stop-min-delta-pct` sets the minimum required improvement percentage (> 0); if omitted while early stopping is enabled, training defaults to `0.1`.
 - `--keep-last-n-epoch-checkpoints` controls how many rolling `last_model_epoch_<i>.zip` files are retained.

--- a/CLI_launch_example.txt
+++ b/CLI_launch_example.txt
@@ -23,5 +23,5 @@ The full set of optional arguments and their default values when not called expl
 
 Notes:
 - `--early-stop-window` enables early stopping on trailing-window percent validation-loss improvement.
-- `--early-stop-min-delta-pct` sets the minimum required improvement percentage.
+- `--early-stop-min-delta-pct` sets the minimum required improvement percentage (> 0); if omitted while early stopping is enabled, training defaults to `0.1`.
 - `--keep-last-n-epoch-checkpoints` controls how many rolling `last_model_epoch_<i>.zip` files are retained.

--- a/CLI_launch_example.txt
+++ b/CLI_launch_example.txt
@@ -9,6 +9,9 @@ python3 train_wide.py \
 --optimizer adamw \
 --lr 3e-4 \
 --weight-decay 0.01 \
+--early-stop-window 8 \
+--early-stop-min-delta-pct 0.15 \
+--keep-last-n-epoch-checkpoints 8 \
 --dropout 0.3 \
 --wandb-id GENIEv3-0-6-Honda-Truth-hA-LFG_Numu_CC_Thresh_p1to1_eventnum_All_NpNpi_MSE_E_Px_Py_Pz_Topology_dmodel256_nh16_wNoise_do0p3 \
 --save-path /exp/dune/data/users/cborden/save_genie-dmodel_TEST/model/test/GENIEv3-0-6-Honda-Truth-hA-LFG_Numu_CC_Thresh_p1to1_eventnum_All_NpNpi_MSE_E_Px_Py_Pz_Topology_dmodel256_nh16_wNoise_do0p3 \
@@ -17,3 +20,8 @@ python3 train_wide.py \
 --base-config /home/cborden/git/josh_transformer_EE/transformer_EE/transformer_ee/config/wEID/input_GENIEv3-0-6-Honda-Truth-hA-LFG_Numu_CC_Thresh_p1to1_eventnum_All_NpNpi_MSE_E_Px_Py_Pz_Topology.json 
 
 The full set of optional arguments and their default values when not called explicitly can be found in train_wide.py
+
+Notes:
+- `--early-stop-window` enables early stopping on trailing-window percent validation-loss improvement.
+- `--early-stop-min-delta-pct` sets the minimum required improvement percentage.
+- `--keep-last-n-epoch-checkpoints` controls how many rolling `last_model_epoch_<i>.zip` files are retained.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,37 @@ There is an example script for the NC dataset. To run the code, run the followin
 python3 train_script.py
 ```
 
+For the flexible CLI launcher used in many campaigns:
+```
+python3 train_wide.py --base-config <config.json> --epochs 50
+```
+
+### Checkpoint behavior
+
+Training now writes checkpoint files with clearer semantics:
+
+* `best_model.zip`: lowest validation-loss model observed so far.
+* `last_model.zip`: latest epoch model (removed automatically if it is identical to the best epoch).
+* Optional rolling epoch snapshots: `last_model_epoch_<i>.zip` (configurable retention).
+* `checkpoint_metadata.json`: compact metadata with best/last epoch and validation loss,
+  retained rolling checkpoint names, and early-stopping status.
+
+The best-loss sentinel is initialized scale-independently using `+inf` (instead of a fixed
+numeric threshold), which is robust for large-magnitude losses such as MACE-based objectives.
+
+### Early stopping (train_wide.py)
+
+`train_wide.py` supports optional early stopping based on percentage validation-loss
+improvement over a configurable trailing window:
+
+* `--early-stop-window N`: enable early stopping with a trailing window of `N` epochs.
+* `--early-stop-min-delta-pct P`: minimum required percentage improvement over the window.
+* `--keep-last-n-epoch-checkpoints K`: keep a rolling set of `K` epoch-specific
+  `last_model_epoch_<i>.zip` checkpoints.
+
+If early stopping is not enabled, training behavior is unchanged apart from richer
+checkpointing metadata and safer eval fallback behavior.
+
 ## Configuring the code
 The config file is a json file. The default config file is located at transformer_ee/config.
 There are two ways to configure the code:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ numeric threshold), which is robust for large-magnitude losses such as MACE-base
 improvement over a configurable trailing window:
 
 * `--early-stop-window N`: enable early stopping with a trailing window of `N` epochs.
-* `--early-stop-min-delta-pct P`: minimum required percentage improvement over the window.
+* `--early-stop-min-delta-pct P`: minimum required percentage improvement over the window (must be > 0 when early stopping is enabled; defaults to `0.1`).
 * `--keep-last-n-epoch-checkpoints K`: keep a rolling set of `K` epoch-specific
   `last_model_epoch_<i>.zip` checkpoints.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ numeric threshold), which is robust for large-magnitude losses such as MACE-base
 `train_wide.py` supports optional early stopping based on percentage validation-loss
 improvement over a configurable trailing window:
 
-* `--early-stop-window N`: enable early stopping with a trailing window of `N` epochs.
+* `--early-stop-window N`: enable early stopping with a trailing window of `N` epochs (`N >= 2`).
 * `--early-stop-min-delta-pct P`: minimum required percentage improvement over the window (must be > 0 when early stopping is enabled; defaults to `0.1`).
 * `--keep-last-n-epoch-checkpoints K`: keep a rolling set of `K` epoch-specific
   `last_model_epoch_<i>.zip` checkpoints.

--- a/train_wide.py
+++ b/train_wide.py
@@ -184,6 +184,24 @@ def build_argparser():
 
     # Training / Optim
     p.add_argument("--epochs", type=int, default=20)
+    p.add_argument(
+        "--early-stop-window",
+        type=int,
+        default=None,
+        help="Enable early stopping with this trailing epoch window size.",
+    )
+    p.add_argument(
+        "--early-stop-min-delta-pct",
+        type=float,
+        default=None,
+        help="Minimum percent validation-loss improvement required across the early-stop window.",
+    )
+    p.add_argument(
+        "--keep-last-n-epoch-checkpoints",
+        type=int,
+        default=None,
+        help="Retain rolling last_model_epoch_<i>.zip checkpoints (0 disables).",
+    )
     p.add_argument("--optimizer", default="sgd", choices=["sgd", "adam", "adamw"])
     p.add_argument("--lr", type=float, default=0.01)
     p.add_argument("--momentum", type=float, default=0.9)  # only for SGD
@@ -241,6 +259,21 @@ def main():
     kset(cfg, "num_workers", args.num_workers)
 
     kset(cfg, "model.epochs", args.epochs)
+
+    # Optional early-stopping/checkpoint policy (CLI-driven).
+    if args.early_stop_window is not None or args.early_stop_min_delta_pct is not None:
+        early_cfg = cfg.get("early_stopping", {})
+        early_cfg["enabled"] = True
+        if args.early_stop_window is not None:
+            early_cfg["window"] = int(args.early_stop_window)
+        if args.early_stop_min_delta_pct is not None:
+            early_cfg["min_delta_pct"] = float(args.early_stop_min_delta_pct)
+        cfg["early_stopping"] = early_cfg
+
+    if args.keep_last_n_epoch_checkpoints is not None:
+        ckpt_cfg = cfg.get("checkpointing", {})
+        ckpt_cfg["keep_last_n_epoch_checkpoints"] = int(args.keep_last_n_epoch_checkpoints)
+        cfg["checkpointing"] = ckpt_cfg
 
     # --- Optional noise configuration (mirrors train_script.py example) ---
     if args.enable_noise:

--- a/train_wide.py
+++ b/train_wide.py
@@ -188,7 +188,7 @@ def build_argparser():
         "--early-stop-window",
         type=int,
         default=None,
-        help="Enable early stopping with this trailing epoch window size.",
+        help="Enable early stopping with this trailing epoch window size (must be >= 2).",
     )
     p.add_argument(
         "--early-stop-min-delta-pct",
@@ -246,7 +246,11 @@ def build_argparser():
 
 
 def main():
-    args = build_argparser().parse_args()
+    parser = build_argparser()
+    args = parser.parse_args()
+
+    if args.early_stop_window is not None and args.early_stop_window < 2:
+        parser.error("--early-stop-window must be >= 2 when early stopping is enabled.")
 
     # Load base config
     with open(args.base_config, "r", encoding="utf-8") as f:

--- a/transformer_ee/train/train.py
+++ b/transformer_ee/train/train.py
@@ -95,7 +95,18 @@ class MVtrainer:
         # drops below min_delta_pct.
         early_cfg = self.input_d.get("early_stopping", {})
         self.early_stopping_enabled = bool(early_cfg.get("enabled", False))
-        self.early_stopping_window = max(1, int(early_cfg.get("window", 5)))
+        configured_window = int(early_cfg.get("window", 5))
+        if self.early_stopping_enabled and configured_window < 2:
+            raise ValueError(
+                "early_stopping.window must be >= 2 when early stopping is enabled. "
+                f"Received {configured_window}."
+            )
+        self.early_stopping_window = (
+            max(2, configured_window)
+            if self.early_stopping_enabled
+            else max(1, configured_window)
+        )
+
         default_min_delta_pct = 0.1
         self.early_stopping_min_delta_pct = float(
             early_cfg.get("min_delta_pct", default_min_delta_pct)

--- a/transformer_ee/train/train.py
+++ b/transformer_ee/train/train.py
@@ -96,7 +96,15 @@ class MVtrainer:
         early_cfg = self.input_d.get("early_stopping", {})
         self.early_stopping_enabled = bool(early_cfg.get("enabled", False))
         self.early_stopping_window = max(1, int(early_cfg.get("window", 5)))
-        self.early_stopping_min_delta_pct = float(early_cfg.get("min_delta_pct", 0.0))
+        default_min_delta_pct = 0.1
+        self.early_stopping_min_delta_pct = float(
+            early_cfg.get("min_delta_pct", default_min_delta_pct)
+        )
+        if self.early_stopping_enabled and self.early_stopping_min_delta_pct <= 0.0:
+            raise ValueError(
+                "early_stopping.min_delta_pct must be > 0 when early stopping is enabled. "
+                f"Received {self.early_stopping_min_delta_pct}."
+            )
         self.early_stop_triggered = False
         self.early_stop_epoch: int | None = None
 

--- a/transformer_ee/train/train.py
+++ b/transformer_ee/train/train.py
@@ -448,16 +448,32 @@ class MVtrainer:
 
     def _write_checkpoint_metadata(self):
         """Persist compact checkpoint/training status metadata for reproducibility."""
+        best_filename = "best_model.zip" if os.path.exists(os.path.join(self.save_path, "best_model.zip")) else None
+        last_filename = "last_model.zip" if os.path.exists(os.path.join(self.save_path, "last_model.zip")) else None
+
+        latest_filename = last_filename or best_filename
+        latest_epoch = self.last_model_epoch if last_filename is not None else self.best_model_epoch
+        latest_val_loss = (
+            self.last_model_val_loss
+            if last_filename is not None
+            else self.best_model_val_loss
+        )
+
         metadata = {
             "best_model": {
                 "epoch": self.best_model_epoch,
                 "validation_loss": self.best_model_val_loss,
-                "filename": "best_model.zip",
+                "filename": best_filename,
             },
             "last_model": {
                 "epoch": self.last_model_epoch,
                 "validation_loss": self.last_model_val_loss,
-                "filename": "last_model.zip",
+                "filename": last_filename,
+            },
+            "latest_checkpoint": {
+                "epoch": latest_epoch,
+                "validation_loss": latest_val_loss,
+                "filename": latest_filename,
             },
             "keep_last_n_epoch_checkpoints": self.keep_last_n_epoch_checkpoints,
             "retained_last_model_epoch_checkpoints": self._epoch_checkpoint_history,
@@ -473,7 +489,7 @@ class MVtrainer:
             json.dump(metadata, f, indent=4)
 
     def _finalize_checkpoint_layout(self):
-        """Remove redundant last_model.zip when best model occurred on final epoch."""
+        """Keep best_model.zip canonical; keep last_model.zip only when it differs."""
         if self.best_model_epoch is not None and self.last_model_epoch == self.best_model_epoch:
             last_model_path = os.path.join(self.save_path, "last_model.zip")
             if os.path.exists(last_model_path):


### PR DESCRIPTION
### Motivation
- Make best-loss tracking explicit and scale-independent (important for large-magnitude/MACE-style losses) by using a +inf sentinel and clearer field names. 
- Improve checkpointing so training is recoverable, supports long runs, and avoids accidental overtraining by preserving best/last models and optional rolling epoch snapshots. 
- Provide a simple, configurable early-stop rule (percent improvement over a trailing window) accessible from the CLI to stop runs automatically.

### Description
- Replaced the legacy `bestscore` with `best_val_loss_sentinel` and added explicit tracking fields `best_model_epoch`, `best_model_val_loss`, `last_model_epoch`, and `last_model_val_loss` in `transformer_ee/train/train.py`. 
- Implemented checkpoint lifecycle in `MVtrainer`: always write `last_model.zip` each epoch, write `best_model.zip` when validation loss improves, optionally write and prune `last_model_epoch_<i>.zip` snapshots, and emit `checkpoint_metadata.json`; redundant `last_model.zip` is removed when the final epoch is also the best. 
- Added percent-improvement early stopping logic (trailing-window) integrated into both training loops, plus CLI support in `train_wide.py` for `--early-stop-window`, `--early-stop-min-delta-pct`, and `--keep-last-n-epoch-checkpoints`, which are wired into the config. 
- Made evaluation robust by preferring `best_model.zip` and falling back to `last_model.zip` if needed, and updated `README.md` and `CLI_launch_example.txt` to document new checkpointing and early-stopping behavior.

### Testing
- Compiled the modified modules with `python -m compileall transformer_ee/train/train.py train_wide.py`, which completed successfully. 
- Confirmed the old `bestscore` identifier is gone with `rg -n "bestscore" -S` (no matches). 
- Basic repository sanity checks were performed and no compile-time errors were reported for the edited files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699775362964832e981d29e891445267)