### PR TITLE
Fix empty multiplicity plots and NC output naming in ScalarLept_wNC.C

### DIFF
--- a/preprocessing_GENIE_files/codes/ScalarLept_wNC.C
+++ b/preprocessing_GENIE_files/codes/ScalarLept_wNC.C
@@ -735,7 +735,7 @@ void ScalarLept_wNC(const std::string &input_file)
             continue;
 
         int n_prot = 0, n_piplus = 0, n_piminus = 0, n_pizero = 0, n_pi = 0, visible_count = 0;
-        int N_GAMMAS;
+        int N_GAMMAS = 0;
 
         energies.clear();
         masses.clear();
@@ -1369,6 +1369,15 @@ void ScalarLept_wNC(const std::string &input_file)
             }
 
             // ////do_resize(pdgs,masses,energies,pxs,pys,pzs,costheta_arr,theta_arr);
+
+            Fin_Prot_Mult->Fill(n_prot);
+            n_prot = 0;
+            Fin_PiPlus_Mult->Fill(n_piplus);
+            n_piplus = 0;
+            Fin_PiMinus_Mult->Fill(n_piminus);
+            n_piminus = 0;
+            Fin_PiZero_Mult->Fill(n_pizero);
+            n_pizero = 0;
 
             if (pdgs.empty())
             {
@@ -2131,20 +2140,20 @@ void ScalarLept_wNC(const std::string &input_file)
     Fin_NC_Lept_Mom->Draw("hist");
     c1->SetLogy(1);
     c1->BuildLegend(0.5, 0.3, 0.9, 0.7);
-    c1->Print((directory + "/" + last_name + "Fin_CC_Lept_Mom.png").c_str());
-    c1->Print((directory + "/" + last_name + "Fin_CC_Lept_Mom.root").c_str());
+    c1->Print((directory + "/" + last_name + "Fin_NC_Lept_Mom.png").c_str());
+    c1->Print((directory + "/" + last_name + "Fin_NC_Lept_Mom.root").c_str());
     c1->Clear();
 
     Fin_NC_Lept_Theta->Draw("hist");
     c1->SetLogy(0);
-    c1->Print((directory + "/" + last_name + "Fin_CC_Lept_Theta.png").c_str());
-    c1->Print((directory + "/" + last_name + "Fin_CC_Lept_Theta.root").c_str());
+    c1->Print((directory + "/" + last_name + "Fin_NC_Lept_Theta.png").c_str());
+    c1->Print((directory + "/" + last_name + "Fin_NC_Lept_Theta.root").c_str());
     c1->Clear();
 
     Fin_NC_Lept_CosTheta->Draw("hist");
     c1->SetLogy(0);
-    c1->Print((directory + "/" + last_name + "Fin_CC_Lept_CosTheta.png").c_str());
-    c1->Print((directory + "/" + last_name + "Fin_CC_Lept_CosTheta.root").c_str());
+    c1->Print((directory + "/" + last_name + "Fin_NC_Lept_CosTheta.png").c_str());
+    c1->Print((directory + "/" + last_name + "Fin_NC_Lept_CosTheta.root").c_str());
     c1->Clear();
 
     Fin_Prot_Mom->Draw("hist");


### PR DESCRIPTION
### Motivation
- Multiplicity histograms (`Fin_Prot_Mult`, `Fin_PiPlus_Mult`, `Fin_PiMinus_Mult`, `Fin_PiZero_Mult`) were empty for the `ScalarLept_wNC.C` CC-selection branch even though events were produced, indicating missing histogram fills in that branch. 
- An uninitialized counter `N_GAMMAS` could produce undefined behaviour when incremented. 
- NC lepton canvases were being exported with CC filenames, causing misnamed/overwritten NC outputs.

### Description
- In `preprocessing_GENIE_files/codes/ScalarLept_wNC.C` initialized `N_GAMMAS` to `0` to avoid undefined increments (`int N_GAMMAS = 0;`).
- Added the missing multiplicity fill/reset block to the previously-missing CC-selection branch so `Fin_Prot_Mult`, `Fin_PiPlus_Mult`, `Fin_PiMinus_Mult`, and `Fin_PiZero_Mult` are filled and reset consistently with the other branches (`Fin_..._Mult->Fill(...)` followed by setting counters to 0).
- Corrected NC lepton canvas export filenames to use `Fin_NC_...` instead of incorrectly using the CC filenames, preventing mislabeling/overwrites of NC plots.

### Testing
- Verified parity of multiplicity fill sites between `ScalarLept_wNC.C` and `VectorLept_wNC.C` by code inspection and diffing, confirming the scalar branch now contains the same multiplicity fills as the vector implementation (success).
- Confirmed `N_GAMMAS` is initialized and that the newly-inserted fill/reset block appears at the expected locations in the file (success).
- Attempted runtime validation of the ROOT macros but `root` is not available in this environment, so end-to-end macro execution and image generation could not be performed (skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3546b4044832e9029912970fab1b7)