### PR TITLE
Integrate Richi-style robustness selectors and topology overlays into eval_model.C

### DIFF
--- a/graph_eval/eval_model.C
+++ b/graph_eval/eval_model.C
@@ -105,6 +105,29 @@ bool isCosThetaVar(const std::string& base) {
            (base.find("cos_theta")    != std::string::npos);
 }
 
+// Parse comma-separated numeric tokens (e.g. "100200300,110000000").
+std::vector<long long> parseTopologyCodeList(const std::string& csv) {
+    std::vector<long long> codes;
+    std::stringstream ss(csv);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+        size_t b = token.find_first_not_of(" \t\r\n");
+        size_t e = token.find_last_not_of(" \t\r\n");
+        if (b == std::string::npos) continue;
+        std::string trimmed = token.substr(b, e - b + 1);
+        try {
+            codes.push_back(std::stoll(trimmed));
+        } catch (...) {
+            std::cerr << "[WARNING] Ignoring non-numeric topology code token: '" << trimmed << "'\n";
+        }
+    }
+    return codes;
+}
+
+std::string topologyCodeLabel(long long code) {
+    return std::string("topo_") + std::to_string(code);
+}
+
 /// === Contour / ellipse helpers (adapted from plot_2d_hist_contour.C) ===
 std::vector<double> calcLevels(TH2D* h, const std::vector<double>& probs) {
     std::vector<double> vals;
@@ -309,6 +332,7 @@ void updateEllipseCSV(const std::string& modelName,
 
 /// === 2D resolution graphing helper ===
 void graph_resolution_stat(
+    const std::string& name_prefix,
     const std::string& base_var,
     const std::vector<double>& x_data,
     const std::vector<double>& resolution,
@@ -386,7 +410,7 @@ void graph_resolution_stat(
         ymax += 1.0;
     }
 
-    std::string name = "gr_" + base_var + "_" + stat2;
+    std::string name = name_prefix + "gr_" + base_var + "_" + stat2;
     TCanvas* c = new TCanvas(name.c_str(), name.c_str(), 800, 600);
     gStyle->SetOptStat(0);
     TGraphErrors* gr = new TGraphErrors(bins, &bin_x[0], &bin_yval[0], &bin_xerr[0], &bin_yerr[0]);
@@ -500,7 +524,8 @@ std::pair<double,double> finite_minmax(const std::vector<double>& v) {
     return {vmin, vmax};
 }
 
-void plot_truth_vs_reco_2d(const std::string& base,
+void plot_truth_vs_reco_2d(const std::string& name_prefix,
+                            const std::string& base,
                             const std::vector<double>& vtrue,
                             const std::vector<double>& vreco,
                             TDirectory* outdir,
@@ -566,7 +591,7 @@ void plot_truth_vs_reco_2d(const std::string& base,
 
 
     // Build histogram (x = truth, y = reco)
-    std::string hname = "h2_" + base + "_reco_vs_true";
+    std::string hname = name_prefix + "h2_" + base + "_reco_vs_true";
     std::string htitle = base + ": reconstructed vs true;true " + base + ";reconstructed " + base;
     TH2D* h2 = new TH2D(hname.c_str(), htitle.c_str(), nbins, xmin, xmax, nbins, xmin, xmax);
     h2->SetDirectory(0);
@@ -579,7 +604,7 @@ void plot_truth_vs_reco_2d(const std::string& base,
     }
 
     // Draw
-    std::string cname = "c2_" + base + "_reco_vs_true";
+    std::string cname = name_prefix + "c2_" + base + "_reco_vs_true";
     TCanvas* c = new TCanvas(cname.c_str(), cname.c_str(), 900, 800);
     gStyle->SetOptStat(0);
     h2->Draw("COLZ");
@@ -656,7 +681,12 @@ void eval_model(
     const char* png_path = "",
     int png_width = 0,
     int png_height = 0,
-    const char* root_output_name = "combined_output.root"
+    const char* root_output_name = "combined_output.root",
+    const char* topology_codes_csv = "",
+    double true_energy_min = -1.0,
+    double true_energy_max = -1.0,
+    double true_theta_min_deg = -1.0,
+    double true_theta_max_deg = -1.0
     ) {
 
      // Put ROOT into batch mode so canvases are not shown on screen
@@ -680,6 +710,30 @@ void eval_model(
         gSystem->ChangeDirectory(original_dir.c_str());
         gROOT->SetBatch(oldBatch); // restore batch state before returning
         return;
+    }
+
+
+    // === Optional selection controls (added for robustness studies) ===
+    // These options are additive: default values preserve legacy behavior.
+    const std::vector<long long> selected_topology_codes =
+        parseTopologyCodeList(topology_codes_csv ? topology_codes_csv : "");
+    const bool apply_topology_filter = !selected_topology_codes.empty();
+    const bool apply_true_energy_cut = (true_energy_min < true_energy_max);
+    const bool apply_true_theta_cut = (true_theta_min_deg < true_theta_max_deg);
+
+    std::set<long long> selected_topology_set(selected_topology_codes.begin(), selected_topology_codes.end());
+
+    if (apply_topology_filter) {
+        std::cout << "[INFO] Topology selection enabled for " << selected_topology_set.size()
+                  << " code(s)." << std::endl;
+    }
+    if (apply_true_energy_cut) {
+        std::cout << "[INFO] True-energy cut enabled: [" << true_energy_min << ", "
+                  << true_energy_max << "] GeV" << std::endl;
+    }
+    if (apply_true_theta_cut) {
+        std::cout << "[INFO] True-theta cut enabled: [" << true_theta_min_deg << ", "
+                  << true_theta_max_deg << "] deg" << std::endl;
     }
 
     // === Parse header ===
@@ -806,29 +860,6 @@ void eval_model(
                 }
             }
         }
-        //Topology Code Here
-        // --- Topology filter: keep only 1 proton and 1 pion ---
-    // if (colIndex.find("true_Topology") != colIndex.end()) {
-    
-    //     double topo_double = row[colIndex["true_Topology"]];
-    //     long long topo_int = static_cast<long long>(topo_double);
-    //     std::string topo_str = std::to_string(topo_int);
-    
-    //     while (topo_str.length() < 15)
-    //         topo_str = "0" + topo_str;
-    
-    //     int n_proton  = std::stoi(topo_str.substr(1, 2));
-    //     int n_piplus  = std::stoi(topo_str.substr(5, 2));
-    //     int n_piminus = std::stoi(topo_str.substr(9, 2));
-    //     int n_pizero  = std::stoi(topo_str.substr(13, 2));
-    
-    //     int total_pions = n_piplus + n_piminus + n_pizero;
-    
-    //     if (!(n_proton == 1 && total_pions == 1)) {
-    //         continue;  // reject event
-    //     }
-    // }
-
         if (row.size() != headers.size()) {
             std::cerr << "Skipping line " << line_num << ": column mismatch ("
                       << row.size() << " vs " << headers.size() << ")\n";
@@ -836,6 +867,47 @@ void eval_model(
             continue;
         }
         ++line_num;
+
+        // --- Optional event filtering for robustness studies ---
+        // Topology-code selection (from true_Topology), if requested.
+        if (apply_topology_filter) {
+            auto itTopo = colIndex.find("true_Topology");
+            if (itTopo != colIndex.end()) {
+                double topo_val = row[itTopo->second];
+                if (!std::isfinite(topo_val)) continue;
+                long long topo_code = static_cast<long long>(topo_val);
+                if (selected_topology_set.find(topo_code) == selected_topology_set.end()) continue;
+            }
+        }
+
+        // True-energy cut in GeV, if requested.
+        if (apply_true_energy_cut) {
+            auto itE = colIndex.find("true_Nu_Energy");
+            if (itE != colIndex.end()) {
+                double Etrue = row[itE->second];
+                if (!std::isfinite(Etrue) || Etrue < true_energy_min || Etrue > true_energy_max) continue;
+            }
+        }
+
+        // True-theta cut in degrees, if requested.
+        if (apply_true_theta_cut) {
+            double theta_for_cut = NAN;
+            auto itTheta = colIndex.find("true_Nu_Theta");
+            if (itTheta != colIndex.end()) {
+                theta_for_cut = row[itTheta->second];
+            } else {
+                auto itTx = colIndex.find("true_Nu_Mom_X");
+                auto itTy = colIndex.find("true_Nu_Mom_Y");
+                auto itTz = colIndex.find("true_Nu_Mom_Z");
+                if (itTx != colIndex.end() && itTy != colIndex.end() && itTz != colIndex.end()) {
+                    theta_for_cut = calcTheta(row[itTx->second], row[itTy->second], row[itTz->second]);
+                }
+            }
+            if (std::isfinite(theta_for_cut) &&
+                (theta_for_cut < true_theta_min_deg || theta_for_cut > true_theta_max_deg)) {
+                continue;
+            }
+        }
 
         for (size_t i = 0; i < headers.size(); ++i)
             data[headers[i]].push_back(row[i]);
@@ -1357,8 +1429,8 @@ auto make_hist = [&](const std::string& name, const std::vector<double>& d, doub
         }
 
         // 2D resolution plots with rms or std error bars
-        graph_resolution_stat(base, true_vals, res, "rms", NUM_BINS, XMIN_DEFAULT, XMAX_DEFAULT, plotDir, !cosMode);
-        graph_resolution_stat(base, true_vals, res, "std", NUM_BINS, XMIN_DEFAULT, XMAX_DEFAULT, plotDir, !cosMode);
+        graph_resolution_stat("", base, true_vals, res, "rms", NUM_BINS, XMIN_DEFAULT, XMAX_DEFAULT, plotDir, !cosMode);
+        graph_resolution_stat("", base, true_vals, res, "std", NUM_BINS, XMIN_DEFAULT, XMAX_DEFAULT, plotDir, !cosMode);
 
 
         std::cout << "Writing graph to: " << gDirectory->GetPath() << std::endl;
@@ -1382,7 +1454,7 @@ auto make_hist = [&](const std::string& name, const std::vector<double>& d, doub
             const auto& vreco = itp->second;
 
             // If lengths differ, we safely use min size inside the helper
-            plot_truth_vs_reco_2d(base, vtrue, vreco, plotDir, /*nbins=*/200);
+            plot_truth_vs_reco_2d("", base, vtrue, vreco, plotDir, /*nbins=*/200);
             ++made2D;
         }
         std::cout << "Created " << made2D << " truth-vs-reco 2D histograms." << std::endl;
@@ -1794,6 +1866,174 @@ auto make_hist = [&](const std::string& name, const std::vector<double>& d, doub
 
     } else {
         std::cout << "No 2D entries available; energy/theta 2D histogram not created." << std::endl;
+    }
+
+
+    // === Topology overlays (Richi feature integration) ===
+    // Build per-topology overlays for robustness studies while preserving the
+    // baseline (all-event) plots above.
+    auto itTopoAll = data.find("true_Topology");
+    if (itTopoAll != data.end()) {
+        // Gather topology-index groups.
+        std::map<long long, std::vector<size_t>> topo_to_indices;
+        const auto& topo_values = itTopoAll->second;
+        for (size_t i = 0; i < topo_values.size(); ++i) {
+            if (!std::isfinite(topo_values[i])) continue;
+            long long code = static_cast<long long>(topo_values[i]);
+            topo_to_indices[code].push_back(i);
+        }
+
+        // If user requested specific topology codes, keep only those.
+        if (apply_topology_filter) {
+            for (auto it = topo_to_indices.begin(); it != topo_to_indices.end(); ) {
+                if (selected_topology_set.find(it->first) == selected_topology_set.end()) it = topo_to_indices.erase(it);
+                else ++it;
+            }
+        }
+
+        std::cout << "[INFO] Building topology overlays for " << topo_to_indices.size()
+                  << " topology group(s)." << std::endl;
+
+        // For each topology, recreate key resolution and truth-vs-reco products
+        // with a topology-specific prefix in object names.
+        for (const auto& topo_kv : topo_to_indices) {
+            long long topo_code = topo_kv.first;
+            const auto& indices = topo_kv.second;
+            std::string topo_prefix = topologyCodeLabel(topo_code) + "_";
+
+            // (A) true/pred pair based products for this topology.
+            for (const auto& kv : data) {
+                const std::string& true_key = kv.first;
+                if (true_key.rfind("true_", 0) != 0) continue;
+                std::string base = true_key.substr(5);
+                std::string pred_key = "pred_" + base;
+                auto itPred = data.find(pred_key);
+                if (itPred == data.end()) continue;
+
+                const auto& vtrue_all = kv.second;
+                const auto& vpred_all = itPred->second;
+                std::vector<double> vtrue, vpred;
+                vtrue.reserve(indices.size());
+                vpred.reserve(indices.size());
+
+                for (size_t idx : indices) {
+                    if (idx < vtrue_all.size() && idx < vpred_all.size()) {
+                        vtrue.push_back(vtrue_all[idx]);
+                        vpred.push_back(vpred_all[idx]);
+                    }
+                }
+                if (vtrue.empty() || vpred.empty()) continue;
+
+                // 1D residual/resolution histograms per variable per topology.
+                const bool cosMode = isCosThetaVar(base);
+                std::vector<double> res;
+                res.reserve(std::min(vtrue.size(), vpred.size()));
+                for (size_t i = 0; i < std::min(vtrue.size(), vpred.size()); ++i) {
+                    double t = vtrue[i], p = vpred[i];
+                    if (!std::isfinite(t) || !std::isfinite(p)) continue;
+                    if (cosMode) {
+                        res.push_back(p - t);
+                    } else if (t != 0.0) {
+                        res.push_back(100.0 * (p - t) / t);
+                    }
+                }
+
+                if (!res.empty()) {
+                    std::string hname = topo_prefix + "h1_res_" + base;
+                    double lo = *std::min_element(res.begin(), res.end());
+                    double hi = *std::max_element(res.begin(), res.end());
+                    if (cosMode) {
+                        lo = std::max(lo, -2.0);
+                        hi = std::min(hi,  2.0);
+                    } else {
+                        auto rr = clamp_res_range(lo, hi);
+                        lo = rr.first; hi = rr.second;
+                    }
+                    if (lo == hi) { lo -= 1.0; hi += 1.0; }
+
+                    TH1D* hres = new TH1D(hname.c_str(), hname.c_str(), 200, lo, hi);
+                    hres->SetDirectory(0);
+                    for (double r : res) if (std::isfinite(r)) hres->Fill(r);
+                    if (plotDir) plotDir->cd();
+                    hres->Write(hname.c_str(), TObject::kOverwrite);
+
+                    graph_resolution_stat(topo_prefix, base, vtrue, res, "rms", NUM_BINS,
+                                          XMIN_DEFAULT, XMAX_DEFAULT, plotDir, !cosMode);
+                    graph_resolution_stat(topo_prefix, base, vtrue, res, "std", NUM_BINS,
+                                          XMIN_DEFAULT, XMAX_DEFAULT, plotDir, !cosMode);
+                }
+
+                // Truth-vs-reco 2D with topology prefix.
+                plot_truth_vs_reco_2d(topo_prefix, base, vtrue, vpred, plotDir, /*nbins=*/200);
+            }
+
+            // (B) Energy-resolution vs delta-theta per topology (overlay-compatible objects).
+            auto has_key = [&](const std::string& k) { return data.find(k) != data.end(); };
+            bool has_trueE_t = has_key("true_Nu_Energy");
+            bool has_predE_t = has_key("pred_Nu_Energy");
+            bool has_trueMom_t = has_key("true_Nu_Mom_X") && has_key("true_Nu_Mom_Y") && has_key("true_Nu_Mom_Z");
+            bool has_predMom_t = has_key("pred_Nu_Mom_X") && has_key("pred_Nu_Mom_Y") && has_key("pred_Nu_Mom_Z");
+
+            if (has_trueE_t && has_predE_t && (has_trueMom_t && has_predMom_t)) {
+                std::vector<double> eres_t;
+                std::vector<double> dtheta_t;
+                eres_t.reserve(indices.size());
+                dtheta_t.reserve(indices.size());
+
+                for (size_t idx : indices) {
+                    if (idx >= data["true_Nu_Energy"].size() || idx >= data["pred_Nu_Energy"].size()) continue;
+                    if (idx >= data["true_Nu_Mom_X"].size() || idx >= data["pred_Nu_Mom_X"].size()) continue;
+
+                    double Etrue = data["true_Nu_Energy"][idx];
+                    double Epred = data["pred_Nu_Energy"][idx];
+                    if (!std::isfinite(Etrue) || !std::isfinite(Epred) || Etrue == 0.0) continue;
+
+                    double tt = calcTheta(data["true_Nu_Mom_X"][idx], data["true_Nu_Mom_Y"][idx], data["true_Nu_Mom_Z"][idx]);
+                    double tp = calcTheta(data["pred_Nu_Mom_X"][idx], data["pred_Nu_Mom_Y"][idx], data["pred_Nu_Mom_Z"][idx]);
+                    if (!std::isfinite(tt) || !std::isfinite(tp)) continue;
+
+                    eres_t.push_back(100.0 * (Epred - Etrue) / Etrue);
+                    dtheta_t.push_back(tp - tt);
+                }
+
+                if (!eres_t.empty() && !dtheta_t.empty()) {
+                    auto xr = finite_minmax(eres_t);
+                    auto cr = clamp_res_range(xr.first, xr.second);
+                    double xmin_t = cr.first, xmax_t = cr.second;
+                    if (xmin_t == xmax_t) { xmin_t -= 1.0; xmax_t += 1.0; }
+
+                    double ymin_t = beam_mode ? -0.5 : -180.0;
+                    double ymax_t = beam_mode ?  0.5 :  180.0;
+
+                    std::string hname_t = topo_prefix + "h2_energy_theta";
+                    TH2D* h2t = new TH2D(hname_t.c_str(),
+                        (topo_prefix + "Energy Resolution (%) vs #Delta#theta;Energy Resolution (%);#Delta#theta (deg)").c_str(),
+                        200, xmin_t, xmax_t, 200, ymin_t, ymax_t);
+                    h2t->SetDirectory(0);
+                    for (size_t i = 0; i < eres_t.size(); ++i) h2t->Fill(eres_t[i], dtheta_t[i]);
+
+                    TCanvas* ct = new TCanvas((topo_prefix + "energy_theta_2d").c_str(),
+                                              (topo_prefix + "energy_theta_2d").c_str(), 900, 800);
+                    ct->cd();
+                    h2t->Draw("COLZ");
+
+                    TH2D* hct = (TH2D*)h2t->Clone((topo_prefix + "hcont_energy_theta").c_str());
+                    hct->SetDirectory(0);
+                    hct->Rebin2D(2, 2);
+                    hct->Smooth(1);
+                    std::vector<double> lv = calcLevels(hct, {0.95, 0.90, 0.68});
+                    if (lv.size() == 3) {
+                        drawLargestContourAtLevel(hct, lv[0], kRed+1,    3);
+                        drawLargestContourAtLevel(hct, lv[1], kOrange+7, 3);
+                        drawLargestContourAtLevel(hct, lv[2], kGreen+2,  3);
+                    }
+
+                    if (plotDir) plotDir->cd();
+                    ct->Write((topo_prefix + "energy_theta_2d_canvas").c_str(), TObject::kOverwrite);
+                    h2t->Write(hname_t.c_str(), TObject::kOverwrite);
+                }
+            }
+        }
     }
 
     // Finish writing output file (preserve existing behavior)

--- a/graph_eval/eval_model.C
+++ b/graph_eval/eval_model.C
@@ -1927,13 +1927,17 @@ auto make_hist = [&](const std::string& name, const std::vector<double>& d, doub
                 // 1D residual/resolution histograms per variable per topology.
                 const bool cosMode = isCosThetaVar(base);
                 std::vector<double> res;
+                std::vector<double> vtrue_for_res;
                 res.reserve(std::min(vtrue.size(), vpred.size()));
+                vtrue_for_res.reserve(std::min(vtrue.size(), vpred.size()));
                 for (size_t i = 0; i < std::min(vtrue.size(), vpred.size()); ++i) {
                     double t = vtrue[i], p = vpred[i];
                     if (!std::isfinite(t) || !std::isfinite(p)) continue;
                     if (cosMode) {
+                        vtrue_for_res.push_back(t);
                         res.push_back(p - t);
                     } else if (t != 0.0) {
+                        vtrue_for_res.push_back(t);
                         res.push_back(100.0 * (p - t) / t);
                     }
                 }
@@ -1957,9 +1961,9 @@ auto make_hist = [&](const std::string& name, const std::vector<double>& d, doub
                     if (plotDir) plotDir->cd();
                     hres->Write(hname.c_str(), TObject::kOverwrite);
 
-                    graph_resolution_stat(topo_prefix, base, vtrue, res, "rms", NUM_BINS,
+                    graph_resolution_stat(topo_prefix, base, vtrue_for_res, res, "rms", NUM_BINS,
                                           XMIN_DEFAULT, XMAX_DEFAULT, plotDir, !cosMode);
-                    graph_resolution_stat(topo_prefix, base, vtrue, res, "std", NUM_BINS,
+                    graph_resolution_stat(topo_prefix, base, vtrue_for_res, res, "std", NUM_BINS,
                                           XMIN_DEFAULT, XMAX_DEFAULT, plotDir, !cosMode);
                 }
 

--- a/graph_eval/eval_model.C
+++ b/graph_eval/eval_model.C
@@ -1972,13 +1972,42 @@ auto make_hist = [&](const std::string& name, const std::vector<double>& d, doub
             }
 
             // (B) Energy-resolution vs delta-theta per topology (overlay-compatible objects).
+            // IMPORTANT ROBUSTNESS NOTE (plain language):
+            // For topology overlays we must use the SAME angle-source fallback chain as the
+            // all-event plot (theta column -> momentum xyz -> cos(theta)). If we don't, then
+            // beam-style CSVs that only carry theta/cos(theta) will silently lose per-topology
+            // energy-vs-delta-theta products even though the all-event product exists.
+            //
+            // Edge-case to keep in mind:
+            // A topology slice can have valid energy entries but a mix of NaN/Inf angle entries.
+            // We therefore compute both axes together and only push one aligned (eres, dtheta)
+            // pair at a time after full finite checks. This guarantees overlays compare the
+            // exact same events and avoids topology-by-topology drift from partial filtering.
             auto has_key = [&](const std::string& k) { return data.find(k) != data.end(); };
             bool has_trueE_t = has_key("true_Nu_Energy");
             bool has_predE_t = has_key("pred_Nu_Energy");
             bool has_trueMom_t = has_key("true_Nu_Mom_X") && has_key("true_Nu_Mom_Y") && has_key("true_Nu_Mom_Z");
             bool has_predMom_t = has_key("pred_Nu_Mom_X") && has_key("pred_Nu_Mom_Y") && has_key("pred_Nu_Mom_Z");
+            bool has_theta_t = has_key("true_Nu_Theta") && has_key("pred_Nu_Theta");
 
-            if (has_trueE_t && has_predE_t && (has_trueMom_t && has_predMom_t)) {
+            // Reuse the same key aliases used by the all-event path for consistency.
+            std::string trueCosKey_t = firstExistingKey({
+                "true_Nu_CosTheta",
+                "true_Nu_Cos_Theta",
+                "true_Cos_Theta_nu",
+                "true_Cos_Theta_Nu",
+                "true_CosTheta"
+            });
+            std::string predCosKey_t = firstExistingKey({
+                "pred_Nu_CosTheta",
+                "pred_Nu_Cos_Theta",
+                "pred_Cos_Theta_nu",
+                "pred_Cos_Theta_Nu",
+                "pred_CosTheta"
+            });
+            bool has_costheta_t = (!trueCosKey_t.empty() && !predCosKey_t.empty());
+
+            if (has_trueE_t && has_predE_t && ((has_trueMom_t && has_predMom_t) || has_theta_t || has_costheta_t)) {
                 std::vector<double> eres_t;
                 std::vector<double> dtheta_t;
                 eres_t.reserve(indices.size());
@@ -1986,14 +2015,33 @@ auto make_hist = [&](const std::string& name, const std::vector<double>& d, doub
 
                 for (size_t idx : indices) {
                     if (idx >= data["true_Nu_Energy"].size() || idx >= data["pred_Nu_Energy"].size()) continue;
-                    if (idx >= data["true_Nu_Mom_X"].size() || idx >= data["pred_Nu_Mom_X"].size()) continue;
 
                     double Etrue = data["true_Nu_Energy"][idx];
                     double Epred = data["pred_Nu_Energy"][idx];
                     if (!std::isfinite(Etrue) || !std::isfinite(Epred) || Etrue == 0.0) continue;
 
-                    double tt = calcTheta(data["true_Nu_Mom_X"][idx], data["true_Nu_Mom_Y"][idx], data["true_Nu_Mom_Z"][idx]);
-                    double tp = calcTheta(data["pred_Nu_Mom_X"][idx], data["pred_Nu_Mom_Y"][idx], data["pred_Nu_Mom_Z"][idx]);
+                    double tt = NAN;
+                    double tp = NAN;
+
+                    // Keep this fallback order identical to the all-event logic so topology and
+                    // all-event outputs are directly comparable event-by-event.
+                    if (has_theta_t) {
+                        if (idx >= data["true_Nu_Theta"].size() || idx >= data["pred_Nu_Theta"].size()) continue;
+                        tt = data["true_Nu_Theta"][idx];
+                        tp = data["pred_Nu_Theta"][idx];
+                    } else if (has_trueMom_t && has_predMom_t) {
+                        if (idx >= data["true_Nu_Mom_X"].size() || idx >= data["true_Nu_Mom_Y"].size() || idx >= data["true_Nu_Mom_Z"].size()) continue;
+                        if (idx >= data["pred_Nu_Mom_X"].size() || idx >= data["pred_Nu_Mom_Y"].size() || idx >= data["pred_Nu_Mom_Z"].size()) continue;
+                        tt = calcTheta(data["true_Nu_Mom_X"][idx], data["true_Nu_Mom_Y"][idx], data["true_Nu_Mom_Z"][idx]);
+                        tp = calcTheta(data["pred_Nu_Mom_X"][idx], data["pred_Nu_Mom_Y"][idx], data["pred_Nu_Mom_Z"][idx]);
+                    } else if (has_costheta_t) {
+                        if (idx >= data[trueCosKey_t].size() || idx >= data[predCosKey_t].size()) continue;
+                        tt = thetaFromCos(data[trueCosKey_t][idx]);
+                        tp = thetaFromCos(data[predCosKey_t][idx]);
+                    } else {
+                        continue;
+                    }
+
                     if (!std::isfinite(tt) || !std::isfinite(tp)) continue;
 
                     eres_t.push_back(100.0 * (Epred - Etrue) / Etrue);

--- a/graph_eval/readme_eval.md
+++ b/graph_eval/readme_eval.md
@@ -80,6 +80,8 @@ chmod +x run_eval_all.sh run_full_evals_all_users.sh
   - Computation of the fraction of events inside the ellipse
 * Stores the ellipse fractions in a cumulative `ellipse_fraction.csv` file (auto-created and auto-expanded).
 * Appends or updates a directory inside `combined_output.root` (or a custom ROOT output name) named after the model (taken from the final CSV column header).
+* Adds optional **robustness-study selectors** for true-energy ranges, true-theta ranges, and topology-code subsets.
+* Generates additional topology-prefixed overlays (e.g. `topo_<code>_...`) for resolution, truth-vs-reco, and energy-vs-angle products when `true_Topology` is present.
 * Runs in ROOT **batch mode** so plots are written to file without opening GUI windows.
 
 ## Requirements
@@ -122,9 +124,21 @@ Run the macro from a shell:
 root -l 'eval_model.C("result.csv")'
 ```
 
-Optional arguments can set the output directory, PNG export path/size, and the ROOT
-output filename:
+Optional arguments can set the output directory, PNG export path/size, ROOT
+output filename, and robustness-study selectors:
 
 ```bash
-root -l 'eval_model.C("result.csv", "false", -1.0, "./Results", "energy_theta.png", 3000, 2000, "combined_output.root")'
+root -l 'eval_model.C("result.csv", false, -1.0, "./Results", "energy_theta.png", 3000, 2000, "combined_output.root")'
 ```
+
+```bash
+# Topology and kinematic selection example:
+#   - keep only topology codes 100100000000000 and 100200000000000
+#   - apply 1-5 GeV true-energy cut
+#   - apply 20-60 degree true-theta cut
+root -l 'eval_model.C("result.csv", false, -1.0, "./Results", "", 0, 0, "combined_output.root", "100100000000000,100200000000000", 1.0, 5.0, 20.0, 60.0)'
+```
+
+When topology overlays are active (and `true_Topology` exists in the CSV), ROOT objects
+are written with names prefixed as `topo_<code>_...` so multiple final-state channels can
+be compared directly in one output file.


### PR DESCRIPTION
### Motivation
- Preserve the gold-standard `graph_eval/eval_model.C` behavior while integrating Richi's per-topology overlay and cut-based plotting features for robustness studies. 
- Provide optional, non-breaking selectors so analysts can run per-topology or kinematic-subset evaluations without changing legacy calls. 
- Make topology overlays and cut logic explicit and discoverable to ease future analysis and comparisons across final-state channels.

### Description
- Extended the `eval_model` signature to accept optional selectors: `topology_codes_csv`, `true_energy_min`/`true_energy_max`, and `true_theta_min_deg`/`true_theta_max_deg`, preserving default behavior when not provided. 
- Added `parseTopologyCodeList` and `topologyCodeLabel` helpers and integrated optional per-row event filtering (topology, true-energy, true-theta) during CSV ingestion. 
- Updated plotting helpers `graph_resolution_stat` and `plot_truth_vs_reco_2d` to accept a `name_prefix` so topology-specific objects can be written with `topo_<code>_...` prefixes; implemented per-topology overlays that recreate residual/resolution histograms, RMS/STD graphs, truth-vs-reco 2D histograms, and energy%-vs-Δθ contour products. 
- Kept all original (all-event) outputs unchanged by default, added inline comments for the new blocks, and updated `graph_eval/readme_eval.md` with usage examples for topology and kinematic selection. 

### Testing
- Ran repository inspections and diffs (`git diff`, `git status`, `git show`) to confirm only `graph_eval/eval_model.C` and `graph_eval/readme_eval.md` were modified and then committed successfully. 
- Performed multiple local static text/structure checks (`nl`, `sed`, `rg`) to verify the new helpers, signatures, and prefixing were inserted where intended and that README examples were added. 
- Attempted a local ROOT macro compile/run (`root -l -b -q 'graph_eval/eval_model.C++g'`) but compilation/runtime verification could not be executed in this environment because `root` is not installed (test failed due to missing `root`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa68c38f68832eb390aa2f428acc59)