### PR TITLE
Add configurable model search roots to batch config wrapper

### DIFF
--- a/transformer_ee/inference/configuration_file_tools/CONFIGS_README.md
+++ b/transformer_ee/inference/configuration_file_tools/CONFIGS_README.md
@@ -167,6 +167,28 @@ If they are not in the current working directory, either:
 
 This writes the (currently seven) JSON files into the current directory (or the configured output dir).
 
+### Step 3b — override model search roots when your exports live elsewhere
+
+The wrapper now forwards `--model-search-roots` to the Python generator. You can override roots in two ways:
+
+1) Edit the `MODEL_SEARCH_ROOTS=(...)` array directly in `make_batch_inference_configs.sh`
+2) Pass `MODEL_SEARCH_ROOTS` at runtime as a colon-separated list:
+
+```bash
+MODEL_SEARCH_ROOTS="/my/models/userA:/my/models/userB:/my/models/shared" \
+  ./make_batch_inference_configs.sh
+```
+
+If you prefer to bypass the wrapper, call the generator directly:
+
+```bash
+python3 generate_batch_inference_configs.py \
+  --outdir . \
+  --atm-files Train_Atmospheric_Flat_Models_userA.txt Train_Atmospheric_Flat_Models_userB.txt \
+  --beam-files Train_DUNEBeam_Flat_Models_userA.txt Train_DUNEBeam_Nat_Models_userA.txt Train_NOvABeam_Nat_Models_userA.txt \
+  --model-search-roots /my/models/userA /my/models/userB /my/models/shared
+```
+
 ### Re-running behavior (backups)
 
 By default the generator creates timestamped backups if an output JSON already exists:

--- a/transformer_ee/inference/configuration_file_tools/make_batch_inference_configs.sh
+++ b/transformer_ee/inference/configuration_file_tools/make_batch_inference_configs.sh
@@ -37,19 +37,21 @@ BEAM_FILES=(
 OUTDIR="."
 
 # Override model search roots with either:
-#  1) MODEL_SEARCH_ROOTS as a bash array in this script, or
+#  1) MODEL_SEARCH_ROOTS_DEFAULT as a bash array in this script, or
 #  2) MODEL_SEARCH_ROOTS env var as a colon-separated list.
 #
 # Example:
 #   MODEL_SEARCH_ROOTS="/path/to/a:/path/to/b" ./make_batch_inference_configs.sh
-MODEL_SEARCH_ROOTS=(
+MODEL_SEARCH_ROOTS_DEFAULT=(
   "/exp/dune/data/users/cborden/MLProject/Training_Samples"
   "/exp/dune/data/users/rrichi/MLProject/Training_Samples"
   "/exp/dune/data/users/jbarrow/MLProject/Training_Samples"
 )
 
-if [[ -n "${MODEL_SEARCH_ROOTS:-}" && "${MODEL_SEARCH_ROOTS}" == *":"* ]]; then
+if [[ -n "${MODEL_SEARCH_ROOTS:-}" ]]; then
   IFS=':' read -r -a MODEL_SEARCH_ROOTS <<< "${MODEL_SEARCH_ROOTS}"
+else
+  MODEL_SEARCH_ROOTS=("${MODEL_SEARCH_ROOTS_DEFAULT[@]}")
 fi
 
 python3 generate_batch_inference_configs.py \

--- a/transformer_ee/inference/configuration_file_tools/make_batch_inference_configs.sh
+++ b/transformer_ee/inference/configuration_file_tools/make_batch_inference_configs.sh
@@ -36,7 +36,24 @@ BEAM_FILES=(
 
 OUTDIR="."
 
+# Override model search roots with either:
+#  1) MODEL_SEARCH_ROOTS as a bash array in this script, or
+#  2) MODEL_SEARCH_ROOTS env var as a colon-separated list.
+#
+# Example:
+#   MODEL_SEARCH_ROOTS="/path/to/a:/path/to/b" ./make_batch_inference_configs.sh
+MODEL_SEARCH_ROOTS=(
+  "/exp/dune/data/users/cborden/MLProject/Training_Samples"
+  "/exp/dune/data/users/rrichi/MLProject/Training_Samples"
+  "/exp/dune/data/users/jbarrow/MLProject/Training_Samples"
+)
+
+if [[ -n "${MODEL_SEARCH_ROOTS:-}" && "${MODEL_SEARCH_ROOTS}" == *":"* ]]; then
+  IFS=':' read -r -a MODEL_SEARCH_ROOTS <<< "${MODEL_SEARCH_ROOTS}"
+fi
+
 python3 generate_batch_inference_configs.py \
   --outdir "${OUTDIR}" \
   --atm-files "${ATM_FILES[@]}" \
-  --beam-files "${BEAM_FILES[@]}"
+  --beam-files "${BEAM_FILES[@]}" \
+  --model-search-roots "${MODEL_SEARCH_ROOTS[@]}"


### PR DESCRIPTION
### Motivation

- The existing wrapper forced a fixed set of user model roots, which makes it cumbersome to generate batch config files when trained model exports live in other directories.
- Users need a simple way to point the config generator at alternate model export locations without editing the Python generator each time.

### Description

- Updated `transformer_ee/inference/configuration_file_tools/make_batch_inference_configs.sh` to add a `MODEL_SEARCH_ROOTS=(...)` default array and to accept a colon-separated `MODEL_SEARCH_ROOTS` environment-variable override at runtime.
- The wrapper now forwards the resolved roots to the Python generator via `--model-search-roots` so generated JSON `model_search_roots` match the runtime override.
- Added a new Step 3b to `transformer_ee/inference/configuration_file_tools/CONFIGS_README.md` documenting both the wrapper-based override and the equivalent direct `generate_batch_inference_configs.py` invocation with `--model-search-roots` and examples.
- No changes were required to `generate_batch_inference_configs.py` because it already supports `--model-search-roots` and the same discovery behavior.

### Testing

- Verified the wrapper script parses as valid shell with `bash -n transformer_ee/inference/configuration_file_tools/make_batch_inference_configs.sh` and the check succeeded.
- Verified the generator module compiles with `python3 -m py_compile transformer_ee/inference/configuration_file_tools/generate_batch_inference_configs.py` and the check succeeded.
- Performed a repository diff to confirm the expected changes to `make_batch_inference_configs.sh` and `CONFIGS_README.md` were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae42d4d9a8832eb5b9c1e95efcf27b)