### PR TITLE
Add correlation-focused inference export and ROOT plotting macro

### DIFF
--- a/graph_eval/eval_model_correlations.C
+++ b/graph_eval/eval_model_correlations.C
@@ -1,0 +1,239 @@
+// eval_model_correlations.C
+// Build correlation scatter plots from correlation_inference.py outputs.
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "TCanvas.h"
+#include "TColor.h"
+#include "TFile.h"
+#include "TGraph.h"
+#include "TH2D.h"
+#include "TLine.h"
+#include "TMarker.h"
+#include "TROOT.h"
+#include "TStyle.h"
+#include "TSystem.h"
+
+namespace {
+
+std::vector<std::string> splitCSVLine(const std::string& line) {
+    std::vector<std::string> out;
+    std::stringstream ss(line);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+        out.push_back(token);
+    }
+    return out;
+}
+
+bool toDouble(const std::string& in, double& out) {
+    if (in.empty()) return false;
+    char* end = nullptr;
+    out = std::strtod(in.c_str(), &end);
+    return end != in.c_str() && std::isfinite(out);
+}
+
+std::map<std::string, std::vector<double>> readNumericColumns(
+    const std::string& csvPath,
+    const std::vector<std::string>& requiredColumns,
+    long maxRows,
+    bool& ok
+) {
+    ok = false;
+    std::ifstream fin(csvPath.c_str());
+    if (!fin.is_open()) {
+        std::cerr << "[ERROR] Could not open CSV: " << csvPath << "\n";
+        return {};
+    }
+
+    std::string headerLine;
+    if (!std::getline(fin, headerLine)) {
+        std::cerr << "[ERROR] Empty CSV: " << csvPath << "\n";
+        return {};
+    }
+
+    std::vector<std::string> headers = splitCSVLine(headerLine);
+    std::map<std::string, int> colIndex;
+    for (size_t i = 0; i < headers.size(); ++i) colIndex[headers[i]] = static_cast<int>(i);
+
+    for (const auto& column : requiredColumns) {
+        if (colIndex.find(column) == colIndex.end()) {
+            std::cerr << "[ERROR] Required column not found: " << column << "\n";
+            return {};
+        }
+    }
+
+    std::map<std::string, std::vector<double>> columns;
+    for (const auto& c : requiredColumns) columns[c] = {};
+
+    std::string line;
+    long rowCount = 0;
+    while (std::getline(fin, line)) {
+        if (maxRows > 0 && rowCount >= maxRows) break;
+        std::vector<std::string> fields = splitCSVLine(line);
+        bool rowValid = true;
+        std::map<std::string, double> parsed;
+
+        for (const auto& c : requiredColumns) {
+            int idx = colIndex[c];
+            if (idx < 0 || idx >= static_cast<int>(fields.size())) {
+                rowValid = false;
+                break;
+            }
+            double v = 0.0;
+            if (!toDouble(fields[idx], v)) {
+                rowValid = false;
+                break;
+            }
+            parsed[c] = v;
+        }
+        if (!rowValid) continue;
+
+        for (const auto& c : requiredColumns) columns[c].push_back(parsed[c]);
+        ++rowCount;
+    }
+
+    ok = true;
+    return columns;
+}
+
+void minmax(const std::vector<double>& v, double& lo, double& hi) {
+    lo = std::numeric_limits<double>::infinity();
+    hi = -std::numeric_limits<double>::infinity();
+    for (double x : v) {
+        lo = std::min(lo, x);
+        hi = std::max(hi, x);
+    }
+}
+
+int paletteColor(double norm01) {
+    norm01 = std::max(0.0, std::min(1.0, norm01));
+    int n = gStyle->GetNumberContours();
+    if (n < 2) n = 255;
+    int idx = static_cast<int>(norm01 * (n - 1));
+    return TColor::GetColorPalette(idx);
+}
+
+}  // namespace
+
+void eval_model_correlations(
+    const char* csv_path,
+    const char* x_column,
+    const char* y_column,
+    const char* color_column = "",
+    const char* output_dir = ".",
+    const char* output_stem = "corr_plot",
+    int max_points = -1,
+    bool draw_unity_line = true
+) {
+    gROOT->SetBatch(kTRUE);
+    gStyle->SetOptStat(0);
+    gStyle->SetNumberContours(255);
+
+    std::string xcol = x_column;
+    std::string ycol = y_column;
+    std::string ccol = color_column;
+
+    std::vector<std::string> needed = {xcol, ycol};
+    if (!ccol.empty()) needed.push_back(ccol);
+
+    bool ok = false;
+    std::map<std::string, std::vector<double>> data = readNumericColumns(
+        csv_path,
+        needed,
+        static_cast<long>(max_points),
+        ok
+    );
+    if (!ok) return;
+
+    const auto& x = data[xcol];
+    const auto& y = data[ycol];
+    if (x.empty() || y.empty()) {
+        std::cerr << "[ERROR] No valid rows loaded for plotting.\n";
+        return;
+    }
+
+    double xmin, xmax, ymin, ymax;
+    minmax(x, xmin, xmax);
+    minmax(y, ymin, ymax);
+
+    double xpad = 0.05 * (xmax - xmin + 1e-9);
+    double ypad = 0.05 * (ymax - ymin + 1e-9);
+
+    std::string outDir = output_dir;
+    gSystem->mkdir(outDir.c_str(), true);
+    std::string stem = output_stem;
+
+    TCanvas* canvas = new TCanvas("c_corr", "Correlation plot", 1500, 1100);
+    TH2D* frame = new TH2D(
+        "frame",
+        Form("Correlation; %s; %s", xcol.c_str(), ycol.c_str()),
+        100,
+        xmin - xpad,
+        xmax + xpad,
+        100,
+        ymin - ypad,
+        ymax + ypad
+    );
+    frame->Draw();
+
+    if (!ccol.empty()) {
+        const auto& c = data[ccol];
+        double cmin, cmax;
+        minmax(c, cmin, cmax);
+
+        for (size_t i = 0; i < x.size(); ++i) {
+            double norm = (cmax > cmin) ? (c[i] - cmin) / (cmax - cmin) : 0.5;
+            int color = paletteColor(norm);
+            TMarker* m = new TMarker(x[i], y[i], 20);
+            m->SetMarkerSize(0.45);
+            m->SetMarkerColor(color);
+            m->Draw("same");
+        }
+
+        TH2D* cbar = new TH2D(
+            "cbar", Form(";%s;", ccol.c_str()), 1, cmin, cmax, 255, 0.0, 1.0
+        );
+        for (int ib = 1; ib <= 255; ++ib) cbar->SetBinContent(1, ib, ib);
+        TCanvas* cbarCanvas = new TCanvas("c_colorbar", "Colorbar", 450, 1100);
+        cbar->Draw("colz");
+        cbarCanvas->SaveAs((outDir + "/" + stem + "_colorbar.png").c_str());
+        delete cbarCanvas;
+    } else {
+        TGraph* gr = new TGraph(static_cast<int>(x.size()), x.data(), y.data());
+        gr->SetMarkerStyle(20);
+        gr->SetMarkerSize(0.5);
+        gr->SetMarkerColor(kBlue + 1);
+        gr->Draw("P same");
+    }
+
+    if (draw_unity_line) {
+        double lo = std::max(xmin - xpad, ymin - ypad);
+        double hi = std::min(xmax + xpad, ymax + ypad);
+        TLine* unity = new TLine(lo, lo, hi, hi);
+        unity->SetLineStyle(2);
+        unity->SetLineWidth(2);
+        unity->Draw("same");
+    }
+
+    std::string pngPath = outDir + "/" + stem + ".png";
+    canvas->SaveAs(pngPath.c_str());
+
+    std::string rootPath = outDir + "/" + stem + ".root";
+    TFile fout(rootPath.c_str(), "RECREATE");
+    canvas->Write("corr_canvas");
+    fout.Close();
+
+    std::cout << "[INFO] Saved correlation plot: " << pngPath << "\n";
+    std::cout << "[INFO] Saved ROOT output: " << rootPath << "\n";
+
+    delete canvas;
+}

--- a/graph_eval/eval_model_correlations.C
+++ b/graph_eval/eval_model_correlations.C
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <limits>
@@ -26,11 +27,32 @@ namespace {
 
 std::vector<std::string> splitCSVLine(const std::string& line) {
     std::vector<std::string> out;
-    std::stringstream ss(line);
     std::string token;
-    while (std::getline(ss, token, ',')) {
-        out.push_back(token);
+    bool inQuotes = false;
+
+    for (size_t i = 0; i < line.size(); ++i) {
+        const char ch = line[i];
+
+        if (ch == '"') {
+            if (inQuotes && i + 1 < line.size() && line[i + 1] == '"') {
+                token.push_back('"');
+                ++i;  // consume escaped quote
+            } else {
+                inQuotes = !inQuotes;
+            }
+            continue;
+        }
+
+        if (ch == ',' && !inQuotes) {
+            out.push_back(token);
+            token.clear();
+            continue;
+        }
+
+        token.push_back(ch);
     }
+    out.push_back(token);
+
     return out;
 }
 

--- a/graph_eval/readme_correlation_eval.md
+++ b/graph_eval/readme_correlation_eval.md
@@ -1,0 +1,68 @@
+# Correlation plot macro (`eval_model_correlations.C`)
+
+This macro is designed for outputs from:
+
+- `transformer_ee/inference/correlation_inference.py`
+
+and creates scatter-style correlation plots, optionally color-coded by a third variable.
+
+## File
+
+- `graph_eval/eval_model_correlations.C`
+
+## Usage
+
+### Basic (no color variable)
+
+```bash
+root -l -b -q 'graph_eval/eval_model_correlations.C(
+  "results/sample_with_corr.csv",
+  "true_NuMomMag",
+  "pred_NuMomMag",
+  "",
+  "results/plots",
+  "numomag_corr",
+  -1,
+  true
+)'
+```
+
+### Colored by a third column
+
+```bash
+root -l -b -q 'graph_eval/eval_model_correlations.C(
+  "results/sample_with_corr.csv",
+  "true_LeptKE",
+  "pred_LeptKE",
+  "VisibleEnergyFraction",
+  "results/plots",
+  "leptke_vs_true_colored",
+  200000,
+  true
+)'
+```
+
+## Arguments
+
+1. `csv_path`
+2. `x_column`
+3. `y_column`
+4. `color_column` (empty string disables color-coding)
+5. `output_dir`
+6. `output_stem`
+7. `max_points` (`-1` means all rows)
+8. `draw_unity_line`
+
+## Outputs
+
+In `output_dir`:
+
+- `<output_stem>.png` (main scatter plot)
+- `<output_stem>.root` (canvas saved into ROOT file)
+- `<output_stem>_colorbar.png` (when `color_column` is provided)
+
+## Notes
+
+- Rows with missing/non-numeric values in required columns are skipped.
+- For large files, use `max_points` to keep rendering responsive.
+- The unity line (`y=x`) is useful for quick regression-quality checks.

--- a/transformer_ee/inference/README_correlation_inference.md
+++ b/transformer_ee/inference/README_correlation_inference.md
@@ -1,0 +1,85 @@
+# Correlation-focused inference workflow
+
+This workflow is intended for **validation plots that correlate model outputs with additional truth-level quantities** carried in the same inference CSV.
+
+It adds a dedicated script:
+
+- `transformer_ee/inference/correlation_inference.py`
+
+which writes a single output CSV containing:
+
+1. passthrough columns from the source inference file,
+2. `true_<target>` columns (if available),
+3. `pred_<target>` columns,
+4. `resid_<target> = pred - true` columns.
+
+This keeps everything needed for later studies in one table.
+
+---
+
+## Why this is useful
+
+For plots like:
+
+- `predicted KE` vs `true KE`,
+- marker color from another truth variable (`visible fraction`, topology, etc.),
+
+you need those additional truth columns to survive inference. Rather than rebuilding joins later, this script writes a **correlation-ready table** directly.
+
+---
+
+## Command-line usage
+
+```bash
+python transformer_ee/inference/correlation_inference.py \
+  --model-dir /path/to/model_export \
+  --input-csv /path/to/sample.csv \
+  --output-csv /path/to/results/sample_with_corr.csv \
+  --copy-targets \
+  --copy-columns EventID,NuMomX,NuMomY,NuMomZ \
+  --copy-regex "^(Vis|True|Topology|Nu)" \
+  --write-manifest
+```
+
+### Important flags
+
+- `--copy-columns`
+  - Explicit comma-separated list of columns to copy unchanged.
+- `--copy-regex`
+  - Regex to copy any matching source columns.
+- `--copy-scalars`
+  - Copy scalar inputs used by the model (`input.json -> scalar`).
+- `--copy-targets`
+  - Copy target columns if present (truth validation mode).
+- `--write-manifest`
+  - Writes `<output>.manifest.json` with selected column metadata.
+- `--max-rows`
+  - Useful for smoke tests.
+
+---
+
+## Recommended pattern for truth-correlation studies
+
+1. Include event identifiers (`event`, `EventID`, etc.) in `--copy-columns`.
+2. Include key truth controls via `--copy-columns` and/or `--copy-regex`.
+3. Include targets via `--copy-targets` so each row has `true_` and `pred_` pairs.
+4. Keep the manifest (`--write-manifest`) for reproducibility.
+
+---
+
+## Output schema
+
+Each row corresponds to one input row.
+
+- `event_index`
+- passthrough columns (selected by CLI)
+- `true_<target_i>` (NaN if target absent in input CSV)
+- `pred_<target_i>`
+- `resid_<target_i>`
+
+---
+
+## Notes
+
+- This script is intentionally separate from `batch_inference.py` to keep standard production inference outputs unchanged.
+- If you need this for many model/sample pairs, you can call this script in shell loops or adapt `batch_inference.py` later.

--- a/transformer_ee/inference/correlation_inference.py
+++ b/transformer_ee/inference/correlation_inference.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Inference helper that keeps model predictions plus selected source columns
+for downstream correlation studies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import List, Sequence, Set
+
+import numpy as np
+import pandas as pd
+
+from transformer_ee.inference.pred_wBatch import Predictor
+
+
+def _split_csv_list(raw: str | None) -> List[str]:
+    if not raw:
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run inference and write a correlation-ready output table containing "
+            "predictions, truths, and selected passthrough columns from the input CSV."
+        )
+    )
+    parser.add_argument("--model-dir", required=True, help="Directory with input.json + best_model.zip")
+    parser.add_argument("--input-csv", required=True, help="Inference sample CSV")
+    parser.add_argument("--output-csv", required=True, help="Output CSV path")
+    parser.add_argument(
+        "--copy-columns",
+        default="",
+        help="Comma-separated input CSV columns to passthrough (e.g. EventID,NuMomX)",
+    )
+    parser.add_argument(
+        "--copy-regex",
+        default="",
+        help="Regex applied to input CSV column names. Any match is copied.",
+    )
+    parser.add_argument(
+        "--copy-scalars",
+        action="store_true",
+        help="Copy all scalar features listed in the model input.json.",
+    )
+    parser.add_argument(
+        "--copy-targets",
+        action="store_true",
+        help="Copy target columns from input CSV if present (useful for truth validation samples).",
+    )
+    parser.add_argument(
+        "--max-rows",
+        type=int,
+        default=None,
+        help="Optional row limit for smoke tests.",
+    )
+    parser.add_argument(
+        "--write-manifest",
+        action="store_true",
+        help="Write a JSON manifest next to output CSV describing included columns.",
+    )
+    return parser.parse_args()
+
+
+def resolve_passthrough_columns(
+    dataframe: pd.DataFrame,
+    explicit: Sequence[str],
+    regex_pattern: str,
+    scalar_names: Sequence[str],
+    target_names: Sequence[str],
+    copy_scalars: bool,
+    copy_targets: bool,
+) -> List[str]:
+    selected: Set[str] = set()
+
+    for column in explicit:
+        if column in dataframe.columns:
+            selected.add(column)
+        else:
+            print(f"[WARN] Requested passthrough column '{column}' was not found in input CSV.")
+
+    if copy_scalars:
+        for name in scalar_names:
+            if name in dataframe.columns:
+                selected.add(name)
+
+    if copy_targets:
+        for name in target_names:
+            if name in dataframe.columns:
+                selected.add(name)
+
+    if regex_pattern:
+        matcher = re.compile(regex_pattern)
+        for name in dataframe.columns:
+            if matcher.search(name):
+                selected.add(name)
+
+    return sorted(selected)
+
+
+def main() -> None:
+    args = parse_args()
+    model_dir = Path(args.model_dir).expanduser().resolve()
+    input_csv = Path(args.input_csv).expanduser().resolve()
+    output_csv = Path(args.output_csv).expanduser().resolve()
+
+    df = pd.read_csv(input_csv)
+    if args.max_rows is not None and args.max_rows >= 0:
+        df = df.iloc[: args.max_rows].copy()
+
+    predictor = Predictor(str(model_dir), df.copy())
+    predictions = predictor.go()
+
+    target_names = predictor.train_config.get("target", [])
+    scalar_names = predictor.train_config.get("scalar", [])
+    if len(target_names) != predictions.shape[1]:
+        target_names = [f"target_{i}" for i in range(predictions.shape[1])]
+
+    passthrough_columns = resolve_passthrough_columns(
+        dataframe=df,
+        explicit=_split_csv_list(args.copy_columns),
+        regex_pattern=args.copy_regex,
+        scalar_names=scalar_names,
+        target_names=target_names,
+        copy_scalars=args.copy_scalars,
+        copy_targets=args.copy_targets,
+    )
+
+    result = pd.DataFrame()
+    result["event_index"] = np.arange(len(df), dtype=int)
+
+    for column in passthrough_columns:
+        result[column] = df[column].values
+
+    for idx, name in enumerate(target_names):
+        if name in df.columns:
+            result[f"true_{name}"] = df[name].to_numpy()
+        else:
+            result[f"true_{name}"] = np.full(len(df), np.nan)
+
+    for idx, name in enumerate(target_names):
+        pred_col = predictions[:, idx]
+        result[f"pred_{name}"] = pred_col
+        truth_col = result[f"true_{name}"]
+        result[f"resid_{name}"] = pred_col - truth_col
+
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+    result.to_csv(output_csv, index=False)
+    print(f"[INFO] Wrote correlation-ready inference table: {output_csv}")
+
+    if args.write_manifest:
+        manifest = {
+            "model_dir": str(model_dir),
+            "input_csv": str(input_csv),
+            "output_csv": str(output_csv),
+            "rows": len(result),
+            "targets": target_names,
+            "passthrough_columns": passthrough_columns,
+            "truth_available": [name in df.columns for name in target_names],
+        }
+        manifest_path = output_csv.with_suffix(output_csv.suffix + ".manifest.json")
+        with open(manifest_path, "w", encoding="utf-8") as handle:
+            json.dump(manifest, handle, indent=2)
+        print(f"[INFO] Wrote manifest: {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide an inference-time workflow that carries selected truth-level/input columns alongside model predictions so downstream correlation/validation studies can be produced without additional joins. 
- Keep this functionality separate from existing `batch_inference.py` outputs to avoid changing production inference exports while enabling easy per-sample correlation tables.

### Description
- Add `transformer_ee/inference/correlation_inference.py`, a standalone CLI that runs a model on an input CSV and writes a correlation-ready CSV with `event_index`, selected passthrough columns, `true_<target>`, `pred_<target>`, and `resid_<target>` columns, plus optional JSON manifest; it supports explicit column lists, regex selection, copying scalar input features from `input.json`, and copying target columns when present.
- Add `transformer_ee/inference/README_correlation_inference.md` documenting usage, flags, recommended patterns and output schema for correlation studies.
- Add ROOT macro `graph_eval/eval_model_correlations.C` that reads the new CSV output and produces scatter-style correlation plots with optional third-variable color-coding and a unity line, and add `graph_eval/readme_correlation_eval.md` documenting macro usage and outputs.
- Keep existing `batch_inference.py` behavior unchanged by providing this as a separate utility intended for validation workflows.

### Testing
- Successfully compiled the new Python script with `python -m py_compile transformer_ee/inference/correlation_inference.py` (compilation succeeded).
- Attempted to run the script help (`python transformer_ee/inference/correlation_inference.py --help`) but the runtime import failed in this environment with `ModuleNotFoundError: No module named 'numpy'` so runtime execution was not exercised here.
- Attempted to invoke the ROOT macro entrypoint (`root -l -b -q 'graph_eval/eval_model_correlations.C(...)'`) but the `root` command was not available in the environment, so macro execution was not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3291a979c832ebb8a918a69dccfc0)