### PR TITLE
Add generic ROOT CSV overlay plotting CLI for resolution comparisons

### DIFF
--- a/graph_eval/plot_csv_overlays.C
+++ b/graph_eval/plot_csv_overlays.C
@@ -1,0 +1,383 @@
+// plot_csv_overlays.C
+// General ROOT macro to compare up to 8 CSV distributions with shared styling.
+//
+// Plot spec format (semicolon-separated list, max 8):
+//   file.csv|column_name|legend label|color|line_style|line_width
+// Example:
+//   "/tmp/a.csv|E_MAPE|SV AR23 Natural|kRed|1|2;/tmp/b.csv|E_MAPE|SV G2111a Natural|kBlue|2|2"
+//
+// CLI usage:
+// root -l -b -q 'plot_csv_overlays.C("spec1;spec2",160,-4,4,true,-1,-1,true,0.5,
+//   "Energy Resolution (%)","Normalized Events","DUNE ND comparison","",
+//   "combined_output.root","csv_overlays","energy_overlay","energy_overlay.png")'
+
+#include <TCanvas.h>
+#include <TColor.h>
+#include <TDirectory.h>
+#include <TFile.h>
+#include <TH1D.h>
+#include <TLegend.h>
+#include <TLine.h>
+#include <TROOT.h>
+#include <TStyle.h>
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct PlotSpec {
+  std::string file_path;
+  std::string column_name;
+  std::string legend_label;
+  int color = kBlack;
+  int line_style = 1;
+  int line_width = 2;
+};
+
+static inline std::string trim(const std::string& s) {
+  size_t b = 0;
+  while (b < s.size() && std::isspace(static_cast<unsigned char>(s[b]))) b++;
+  size_t e = s.size();
+  while (e > b && std::isspace(static_cast<unsigned char>(s[e - 1]))) e--;
+  return s.substr(b, e - b);
+}
+
+static std::vector<std::string> split(const std::string& in, char delim) {
+  std::vector<std::string> out;
+  std::stringstream ss(in);
+  std::string token;
+  while (std::getline(ss, token, delim)) out.push_back(trim(token));
+  return out;
+}
+
+static std::vector<std::string> split_csv_simple(const std::string& line) {
+  std::vector<std::string> out;
+  std::string cur;
+  cur.reserve(line.size());
+  bool in_quotes = false;
+
+  for (char ch : line) {
+    if (ch == '"') {
+      in_quotes = !in_quotes;
+      continue;
+    }
+    if (ch == ',' && !in_quotes) {
+      out.push_back(trim(cur));
+      cur.clear();
+    } else {
+      cur.push_back(ch);
+    }
+  }
+  out.push_back(trim(cur));
+  return out;
+}
+
+static bool parse_double(const std::string& s, double& out) {
+  std::string t = trim(s);
+  if (t.empty()) return false;
+  char* end = nullptr;
+  out = std::strtod(t.c_str(), &end);
+  if (end == t.c_str() || *end != '\0') return false;
+  return std::isfinite(out);
+}
+
+static int parse_color(const std::string& token) {
+  std::string t = trim(token);
+  if (t.empty()) return kBlack;
+
+  static const std::map<std::string, int> kMap = {
+      {"kBlack", kBlack},     {"kRed", kRed},         {"kBlue", kBlue},
+      {"kGreen", kGreen},     {"kMagenta", kMagenta}, {"kCyan", kCyan},
+      {"kOrange", kOrange},   {"kViolet", kViolet},   {"kGray", kGray},
+      {"black", kBlack},      {"red", kRed},          {"blue", kBlue},
+      {"green", kGreen},      {"magenta", kMagenta},  {"cyan", kCyan},
+      {"orange", kOrange},    {"violet", kViolet},    {"gray", kGray},
+  };
+
+  auto it = kMap.find(t);
+  if (it != kMap.end()) return it->second;
+
+  double x = 0.0;
+  if (parse_double(t, x)) return static_cast<int>(x);
+
+  std::cerr << "[WARNING] Unknown color token '" << t << "'. Using kBlack.\n";
+  return kBlack;
+}
+
+static PlotSpec parse_plot_spec(const std::string& one_spec) {
+  auto parts = split(one_spec, '|');
+  if (parts.size() < 3) {
+    throw std::runtime_error(
+        "Each plot spec must have at least 3 fields: file|column|label");
+  }
+
+  PlotSpec p;
+  p.file_path = parts[0];
+  p.column_name = parts[1];
+  p.legend_label = parts[2];
+
+  if (parts.size() > 3 && !parts[3].empty()) p.color = parse_color(parts[3]);
+  if (parts.size() > 4 && !parts[4].empty()) p.line_style = std::stoi(parts[4]);
+  if (parts.size() > 5 && !parts[5].empty()) p.line_width = std::stoi(parts[5]);
+
+  return p;
+}
+
+static std::vector<PlotSpec> parse_plot_specs(const std::string& specs) {
+  auto chunks = split(specs, ';');
+  std::vector<PlotSpec> out;
+  out.reserve(chunks.size());
+
+  for (const auto& c : chunks) {
+    if (!c.empty()) out.push_back(parse_plot_spec(c));
+  }
+
+  if (out.empty()) {
+    throw std::runtime_error("No plot specs were provided.");
+  }
+  if (out.size() > 8) {
+    throw std::runtime_error("At most 8 plot specs are allowed per call.");
+  }
+  return out;
+}
+
+static std::vector<double> load_numeric_column(const std::string& path,
+                                               const std::string& col_name) {
+  std::ifstream fin(path);
+  if (!fin) {
+    throw std::runtime_error("Cannot open CSV: " + path);
+  }
+
+  std::string line;
+  if (!std::getline(fin, line)) {
+    throw std::runtime_error("CSV is empty: " + path);
+  }
+
+  auto header = split_csv_simple(line);
+  int col_idx = -1;
+  for (size_t i = 0; i < header.size(); ++i) {
+    if (header[i] == col_name) {
+      col_idx = static_cast<int>(i);
+      break;
+    }
+  }
+  if (col_idx < 0) {
+    std::ostringstream oss;
+    oss << "Column '" << col_name << "' not found in " << path << ". Header fields:";
+    for (const auto& h : header) oss << " " << h;
+    throw std::runtime_error(oss.str());
+  }
+
+  std::vector<double> values;
+  values.reserve(10000);
+  size_t row_num = 1;
+
+  while (std::getline(fin, line)) {
+    row_num++;
+    if (trim(line).empty()) continue;
+    auto fields = split_csv_simple(line);
+    if (static_cast<int>(fields.size()) <= col_idx) {
+      std::cerr << "[WARNING] Skipping malformed row " << row_num << " in " << path
+                << " (not enough columns).\n";
+      continue;
+    }
+
+    double val = 0.0;
+    if (!parse_double(fields[col_idx], val)) continue;
+    values.push_back(val);
+  }
+
+  if (values.empty()) {
+    throw std::runtime_error("No numeric values found for column '" + col_name +
+                             "' in " + path);
+  }
+  return values;
+}
+
+static TDirectory* get_or_make_dir(TFile* fout, const std::string& path) {
+  if (!fout) return nullptr;
+  if (path.empty()) return fout;
+
+  std::stringstream ss(path);
+  std::string segment;
+  TDirectory* current = fout;
+
+  while (std::getline(ss, segment, '/')) {
+    segment = trim(segment);
+    if (segment.empty()) continue;
+
+    TDirectory* next = dynamic_cast<TDirectory*>(current->Get(segment.c_str()));
+    if (!next) next = current->mkdir(segment.c_str());
+    current = next;
+  }
+
+  return current;
+}
+
+}  // namespace
+
+void plot_csv_overlays(
+    const char* plot_specs_c,
+    int nbins = 160,
+    double xmin = -4.0,
+    double xmax = 4.0,
+    bool normalize = true,
+    double ymin = -1.0,
+    double ymax = -1.0,
+    bool draw_vertical_zero = true,
+    double symmetric_vertical = -1.0,
+    const char* x_title_c = "Energy Resolution (%)",
+    const char* y_title_c = "Normalized Events",
+    const char* canvas_title_c = "",
+    const char* legend_header_c = "",
+    const char* output_root_c = "combined_output.root",
+    const char* output_tdirectory_c = "csv_overlay",
+    const char* output_canvas_name_c = "overlay_canvas",
+    const char* output_png_c = "") {
+  try {
+    if (!plot_specs_c || std::string(plot_specs_c).empty()) {
+      throw std::runtime_error("plot_specs string is required.");
+    }
+    if (nbins <= 0) throw std::runtime_error("nbins must be > 0");
+    if (xmax <= xmin) throw std::runtime_error("xmax must be > xmin");
+
+    const std::string x_title = x_title_c ? x_title_c : "X";
+    const std::string y_title = y_title_c ? y_title_c : (normalize ? "Normalized Events" : "Events");
+    const std::string canvas_title = canvas_title_c ? canvas_title_c : "";
+    const std::string legend_header = legend_header_c ? legend_header_c : "";
+    const std::string output_root = output_root_c ? output_root_c : "combined_output.root";
+    const std::string output_tdirectory = output_tdirectory_c ? output_tdirectory_c : "csv_overlay";
+    const std::string output_canvas_name = output_canvas_name_c ? output_canvas_name_c : "overlay_canvas";
+    const std::string output_png = output_png_c ? output_png_c : "";
+
+    auto plot_specs = parse_plot_specs(plot_specs_c);
+
+    gStyle->SetOptStat(0);
+
+    std::vector<std::unique_ptr<TH1D>> hists;
+    hists.reserve(plot_specs.size());
+
+    double max_y = 0.0;
+    for (size_t i = 0; i < plot_specs.size(); ++i) {
+      const auto& spec = plot_specs[i];
+      auto values = load_numeric_column(spec.file_path, spec.column_name);
+
+      std::ostringstream hname;
+      hname << "h_overlay_" << i;
+      auto h = std::make_unique<TH1D>(hname.str().c_str(), "", nbins, xmin, xmax);
+
+      for (double v : values) h->Fill(v);
+
+      if (normalize && h->Integral("width") > 0.0) {
+        h->Scale(1.0 / h->Integral("width"));
+      }
+
+      h->SetLineColor(spec.color);
+      h->SetLineStyle(spec.line_style);
+      h->SetLineWidth(spec.line_width);
+      h->SetTitle(canvas_title.c_str());
+      h->GetXaxis()->SetTitle(x_title.c_str());
+      h->GetYaxis()->SetTitle(y_title.c_str());
+      h->GetXaxis()->CenterTitle();
+      h->GetYaxis()->CenterTitle();
+
+      max_y = std::max(max_y, h->GetMaximum());
+      hists.push_back(std::move(h));
+    }
+
+    if (max_y <= 0.0) max_y = 1.0;
+
+    auto c = std::make_unique<TCanvas>(output_canvas_name.c_str(), output_canvas_name.c_str(), 1600, 1000);
+    c->SetGrid(0, 0);
+
+    if (ymin >= 0.0 || ymax > 0.0) {
+      double lo = (ymin >= 0.0) ? ymin : 0.0;
+      double hi = (ymax > 0.0) ? ymax : max_y * 1.2;
+      hists.front()->SetMinimum(lo);
+      hists.front()->SetMaximum(hi);
+    } else {
+      hists.front()->SetMinimum(0.0);
+      hists.front()->SetMaximum(max_y * 1.2);
+    }
+
+    hists.front()->Draw("hist");
+    for (size_t i = 1; i < hists.size(); ++i) hists[i]->Draw("hist same");
+
+    auto leg = std::make_unique<TLegend>(0.68, 0.66, 0.98, 0.96);
+    leg->SetBorderSize(1);
+    leg->SetFillStyle(0);
+    if (!legend_header.empty()) leg->SetHeader(legend_header.c_str(), "C");
+    for (size_t i = 0; i < plot_specs.size(); ++i) {
+      leg->AddEntry(hists[i].get(), plot_specs[i].legend_label.c_str(), "l");
+    }
+    leg->Draw();
+
+    std::vector<std::unique_ptr<TLine>> lines;
+    if (draw_vertical_zero) {
+      auto line0 = std::make_unique<TLine>(0.0, hists.front()->GetMinimum(), 0.0, hists.front()->GetMaximum());
+      line0->SetLineColor(kGray + 2);
+      line0->SetLineStyle(2);
+      line0->SetLineWidth(2);
+      line0->Draw();
+      lines.push_back(std::move(line0));
+    }
+
+    if (symmetric_vertical > 0.0) {
+      auto lp = std::make_unique<TLine>(symmetric_vertical, hists.front()->GetMinimum(), symmetric_vertical,
+                                        hists.front()->GetMaximum());
+      lp->SetLineColor(kGray + 1);
+      lp->SetLineStyle(7);
+      lp->SetLineWidth(2);
+      lp->Draw();
+
+      auto lm = std::make_unique<TLine>(-symmetric_vertical, hists.front()->GetMinimum(), -symmetric_vertical,
+                                        hists.front()->GetMaximum());
+      lm->SetLineColor(kGray + 1);
+      lm->SetLineStyle(7);
+      lm->SetLineWidth(2);
+      lm->Draw();
+
+      lines.push_back(std::move(lp));
+      lines.push_back(std::move(lm));
+    }
+
+    c->Modified();
+    c->Update();
+
+    std::unique_ptr<TFile> fout(TFile::Open(output_root.c_str(), "UPDATE"));
+    if (!fout || fout->IsZombie()) {
+      throw std::runtime_error("Failed to open ROOT output file: " + output_root);
+    }
+
+    TDirectory* out_dir = get_or_make_dir(fout.get(), output_tdirectory);
+    if (!out_dir) throw std::runtime_error("Failed to create output TDirectory: " + output_tdirectory);
+    out_dir->cd();
+
+    c->Write(output_canvas_name.c_str(), TObject::kOverwrite);
+    for (const auto& h : hists) h->Write(h->GetName(), TObject::kOverwrite);
+    leg->Write((output_canvas_name + std::string("_legend")).c_str(), TObject::kOverwrite);
+
+    fout->Write();
+    fout->Close();
+
+    if (!output_png.empty()) c->SaveAs(output_png.c_str());
+
+    std::cout << "[INFO] Wrote canvas + histograms to " << output_root << " under directory '"
+              << output_tdirectory << "'.\n";
+    if (!output_png.empty()) {
+      std::cout << "[INFO] Saved image: " << output_png << "\n";
+    }
+  } catch (const std::exception& ex) {
+    std::cerr << "[ERROR] plot_csv_overlays failed: " << ex.what() << "\n";
+    throw;
+  }
+}

--- a/graph_eval/readme_eval.md
+++ b/graph_eval/readme_eval.md
@@ -168,3 +168,57 @@ Optional selection controls (examples):
 ```bash
 root -l 'eval_model.C("result.csv", false, -1.0, ".", "", 0, 0, "combined_output.root", "", "301000000000000,300000100000000", 1, 1, 1.0, 5.0, 80.0, 100.0)'
 ```
+
+## plot_csv_overlays.C (new generalized CSV overlay tool)
+
+`plot_csv_overlays.C` is a generic ROOT macro to rapidly compare up to **8** distributions from arbitrary CSV files, with on-the-fly controls tuned for energy/angle/mass-resolution style plots.
+
+### Supported capabilities
+
+1. Normalize each histogram independently (`normalize=true/false`)
+2. Overlay up to 8 curves at once
+3. Per-curve color, line style, and line width
+4. User-defined binning (`nbins`)
+5. User-defined x/y display ranges (`xmin/xmax`, optional `ymin/ymax`)
+6. Vertical guides at `x=0` and optional symmetric guides at `±value`
+7. Output to a single ROOT file with `TDirectory` placement
+
+### Plot-spec format
+
+The first argument is a semicolon-separated list, where each item is:
+
+```text
+file.csv|column_name|legend label|color|line_style|line_width
+```
+
+- `color`: ROOT token (`kRed`, `kBlue`, etc.) or integer color code
+- You may omit trailing style fields; defaults are used.
+
+### Direct ROOT CLI example
+
+```bash
+root -l -b -q 'plot_csv_overlays.C(
+"Noised_FlatvsNat_MVSV_CMCs/E-MAPE__P-MAE/DBNat_on_DBNat_Vector_SV_E_MAPE_P_MAE_AR23.csv|E_MAPE|SV AR23 w/Noise|kRed|1|2;
+Noised_FlatvsNat_MVSV_CMCs/E-MAPE__P-MAE/DBNat_on_DBNat_Vector_SV_E_MAPE_P_MAE_G2111a.csv|E_MAPE|SV G2111a w/Noise|kBlue|1|2",
+220,-4,4,true,-1,-1,true,0.5,
+"Energy Resolution (%)","Normalized Events",
+"DUNE ND-like beam: SV comparison","",
+"combined_output.root","csv_overlay/SV","sv_energy_overlay","sv_energy_overlay.png")'
+```
+
+### Bash wrapper
+
+For faster repeated use, run:
+
+```bash
+./run_csv_overlay.sh \
+  --plots "file1.csv|E_MAPE|SV AR23 Natural|kRed|1|2;file2.csv|E_MAPE|SV G2111a Natural|kBlue|1|2" \
+  --bins 220 --xmin -4 --xmax 4 --normalize true \
+  --draw-v0 true --sym-vline 0.5 \
+  --xtitle "Energy Resolution (%)" --ytitle "Normalized Events" \
+  --title "DUNE Beam Flat vs Natural" \
+  --output-root combined_output.root --tdir csv_overlay/SV \
+  --canvas-name sv_comp --png sv_comp.png
+```
+
+The wrapper forwards all options to `plot_csv_overlays.C` in ROOT batch mode.

--- a/graph_eval/run_csv_overlay.sh
+++ b/graph_eval/run_csv_overlay.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  ./run_csv_overlay.sh \
+    --plots "file.csv|column|label|color|style|width;file2.csv|column|label|color|style|width" \
+    [--bins 160] [--xmin -4] [--xmax 4] [--normalize true] \
+    [--ymin -1] [--ymax -1] [--draw-v0 true] [--sym-vline -1] \
+    [--xtitle "Energy Resolution (%)"] [--ytitle "Normalized Events"] \
+    [--title ""] [--legend-header ""] \
+    [--output-root combined_output.root] [--tdir csv_overlay] \
+    [--canvas-name overlay_canvas] [--png overlay.png]
+
+Notes:
+- Up to 8 plot specs are supported.
+- color can be ROOT color token (kRed, kBlue, ...) or integer code.
+- Use --normalize false to keep raw event counts.
+USAGE
+}
+
+PLOTS=""
+BINS=160
+XMIN=-4
+XMAX=4
+NORMALIZE=true
+YMIN=-1
+YMAX=-1
+DRAW_V0=true
+SYM_VLINE=-1
+XTITLE="Energy Resolution (%)"
+YTITLE="Normalized Events"
+TITLE=""
+LEGEND_HEADER=""
+OUTPUT_ROOT="combined_output.root"
+TDIR="csv_overlay"
+CANVAS_NAME="overlay_canvas"
+PNG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --plots) PLOTS="$2"; shift 2;;
+    --bins) BINS="$2"; shift 2;;
+    --xmin) XMIN="$2"; shift 2;;
+    --xmax) XMAX="$2"; shift 2;;
+    --normalize) NORMALIZE="$2"; shift 2;;
+    --ymin) YMIN="$2"; shift 2;;
+    --ymax) YMAX="$2"; shift 2;;
+    --draw-v0) DRAW_V0="$2"; shift 2;;
+    --sym-vline) SYM_VLINE="$2"; shift 2;;
+    --xtitle) XTITLE="$2"; shift 2;;
+    --ytitle) YTITLE="$2"; shift 2;;
+    --title) TITLE="$2"; shift 2;;
+    --legend-header) LEGEND_HEADER="$2"; shift 2;;
+    --output-root) OUTPUT_ROOT="$2"; shift 2;;
+    --tdir) TDIR="$2"; shift 2;;
+    --canvas-name) CANVAS_NAME="$2"; shift 2;;
+    --png) PNG="$2"; shift 2;;
+    -h|--help) usage; exit 0;;
+    *) echo "Unknown option: $1"; usage; exit 1;;
+  esac
+done
+
+if [[ -z "$PLOTS" ]]; then
+  echo "ERROR: --plots is required."
+  usage
+  exit 1
+fi
+
+root -l -b -q "graph_eval/plot_csv_overlays.C(\"${PLOTS}\",${BINS},${XMIN},${XMAX},${NORMALIZE},${YMIN},${YMAX},${DRAW_V0},${SYM_VLINE},\"${XTITLE}\",\"${YTITLE}\",\"${TITLE}\",\"${LEGEND_HEADER}\",\"${OUTPUT_ROOT}\",\"${TDIR}\",\"${CANVAS_NAME}\",\"${PNG}\")"


### PR DESCRIPTION
### Motivation

- Provide a fast, general-purpose ROOT-based tool to compare energy/angle/mass-resolution-style distributions from CSV inference outputs using a consistent style and single-ROOT-file output organization.
- Enable quick CLI-driven overlays of multiple (up to 8) CSV columns with per-curve styling and axis/layout control to support MV/SV and noise/no-noise comparisons.

### Description

- Added a new ROOT macro `graph_eval/plot_csv_overlays.C` that parses a semicolon-separated plot-spec string and overlays up to 8 histograms with per-curve `color`, `line_style`, and `line_width` controls, robust CSV parsing, and column validation.
- Implemented on-the-fly controls in the macro for normalization, `nbins`, `xmin`/`xmax` and optional `ymin`/`ymax`, a vertical guideline at `x=0`, symmetric vertical lines at `±value`, axis/legend/canvas titles, and optional PNG export.
- Persisted outputs into a single ROOT file with `TDirectory` management (nested directories), writing the canvas, histograms, and legend in a structure compatible with the existing `eval_model.C` flow.
- Added a shell wrapper `graph_eval/run_csv_overlay.sh` to build and call the macro from the CLI, and documented usage and examples in `graph_eval/readme_eval.md`.

### Testing

- Performed a shell syntax check on the wrapper with `bash -n graph_eval/run_csv_overlay.sh`, which succeeded (`OK`).
- Attempted to run the macro in batch mode with `root -l -b -q 'graph_eval/plot_csv_overlays.C("a.csv|x|label")'`, but the run failed because the testing environment does not have the `root` executable (`/bin/bash: root: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32d3d901c832e83643256f107ed7b)